### PR TITLE
Raise a domain_error if the requested method is not available. Also move...

### DIFF
--- a/ssl.doc
+++ b/ssl.doc
@@ -159,6 +159,7 @@ some by both server as client (marked CS).
 	A list of methods to disable. Unsupported methods will be ignored. Methods include:
            \item sslv2
            \item sslv3
+           \item sslv23 (Which is a comibination of both v2 and v3. Disabling this disables both)
            \item tlsv1
            \item tlsv1_1
            \item tlsv1_2

--- a/ssllib.c
+++ b/ssllib.c
@@ -708,7 +708,7 @@ ERR_print_errors_pl()
 
 
 PL_SSL *
-ssl_init(PL_SSL_ROLE role, char* method)
+ssl_init(PL_SSL_ROLE role, const SSL_METHOD *ssl_method)
 /*
  * Allocate the holder for our parameters which will specify the
  * configuration parameters and any other statefull parameter.
@@ -718,29 +718,9 @@ ssl_init(PL_SSL_ROLE role, char* method)
  */
 {
     PL_SSL           * config    = NULL;
-    const SSL_METHOD *ssl_method = NULL;
     SSL_CTX          *ssl_ctx    = NULL;
 
-    if (strcmp(method, "sslv3") == 0)
-      ssl_method = SSLv3_method();
-#ifdef HAVE_SSLV2_METHOD
-    else if (strcmp(method, "sslv2") == 0)
-      ssl_method = SSLv2_method();
-#endif
-#ifdef SSL_OP_NO_TLSv1
-    else if (strcmp(method, "tlsv1") == 0)
-      ssl_method = TLSv1_method();
-#endif
-#ifdef SSL_OP_NO_TLSv1_1
-    else if (strcmp(method, "tlsv1_1") == 0)
-      ssl_method = TLSv1_1_method();
-#endif
-#ifdef SSL_OP_NO_TLSv1_2
-    else if (strcmp(method, "tlsv1_2") == 0)
-      ssl_method = TLSv1_2_method();
-#endif
-    else
-      ssl_method = SSLv23_method();
+
     ssl_ctx = SSL_CTX_new(ssl_method);
     if (!ssl_ctx) {
         ERR_print_errors_pl();

--- a/ssllib.h
+++ b/ssllib.h
@@ -115,7 +115,7 @@ typedef struct ssl_instance {
  */
 int              ssl_lib_init    (void);
 int              ssl_lib_exit    (void);
-PL_SSL *         ssl_init        (PL_SSL_ROLE role, char *method);
+PL_SSL *         ssl_init        (PL_SSL_ROLE role, const SSL_METHOD *method);
 int              ssl_config      (PL_SSL *config);
 int              ssl_socket      (PL_SSL *config);
 PL_SSL_INSTANCE *ssl_ssl_bio	 (PL_SSL *config, IOSTREAM* sread, IOSTREAM* swrite);


### PR DESCRIPTION
... the checking into ssl4pl from ssllib to simplify raising this exception. Add sslv23 as an explicit option so it can be handled uniformly
