### PR TITLE
Added missing include of config.h

### DIFF
--- a/ssllib.c
+++ b/ssllib.c
@@ -20,6 +20,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include <config.h>
 #include <string.h>
 #include <assert.h>
 #include <stdarg.h>


### PR DESCRIPTION
Without this commit I am getting error when compiling on freebsd:
"ssllib.c:82:42: error: use of undeclared identifier 'PTHREAD_MUTEX_INITIALIZER'"