### PR TITLE
remove unnecessary single quotes

### DIFF
--- a/https.pl
+++ b/https.pl
@@ -29,9 +29,9 @@
 :- else.
 :- use_module('../http/demo_body').		% location in demo tree
 :- endif.
-:- use_module(library('http/thread_httpd')).
-:- if(exists_source(library('http/http_ssl_plugin'))).
-:- use_module(library('http/http_ssl_plugin')).
+:- use_module(library(http/thread_httpd)).
+:- if(exists_source(library(http/http_ssl_plugin))).
+:- use_module(library(http/http_ssl_plugin)).
 :- else.
 :- use_module(http_ssl_plugin).
 :- endif.


### PR DESCRIPTION
This example will be quite often used to provide HTTPS servers.