### PR TITLE
ADDED: Option cipher_list(Atom) when cerating an SSL context

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -206,7 +206,7 @@ easily be used.
 %	  Default is `false`.
 %	  * disable_ssl_methods(+List)
 %	  A list of methods to disable. Unsupported methods will be
-%	  ignored. Methods include `sslv2`, `sslv2`, `sslv23`,
+%	  ignored. Methods include `sslv2`, `sslv3`, `sslv23`,
 %	  `tlsv1`, `tlsv1_1` and `tlsv1_2`.
 %	  * ssl_method(+Method)
 %	  Specify the explicit Method to use when negotiating. For

--- a/ssl.pl
+++ b/ssl.pl
@@ -78,6 +78,7 @@
 		       certificate_file(atom),
 		       key_file(atom),
 		       password(any),
+		       cipher_list(any),
 		       pem_password_hook(callable),
 		       cacert_file(any),
                        crl(any),
@@ -191,6 +192,9 @@ easily be used.
 %	  predicate succeeds. See load_certificate/2 for a description
 %	  of the certificate terms. See cert_accept_any/5 for a dummy
 %	  implementation that accepts any certificate.
+%	  * cipher_list(+Atom)
+%	  Specify a cipher preference list (one or more cipher strings
+%	  separated by colons, commas or spaces).
 %	  * cert(+Boolean)
 %	  Trigger the sending of our certificate specified by
 %	  certificate_file(FileName).  Sending is automatic for the

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -60,6 +60,7 @@ static atom_t ATOM_pem_password_hook;
 static atom_t ATOM_cert_verify_hook;
 static atom_t ATOM_close_parent;
 static atom_t ATOM_disable_ssl_methods;
+static atom_t ATOM_cipher_list;
 static atom_t ATOM_root_certificates;
 
 static atom_t ATOM_sslv2;
@@ -1182,6 +1183,13 @@ pl_ssl_context(term_t role, term_t config, term_t options, term_t method)
 	return FALSE;
 
       ssl_set_password(conf, s);
+    } else if ( name == ATOM_cipher_list && arity == 1 )
+    { char *s;
+
+      if ( !get_char_arg(1, head, &s) )
+	return FALSE;
+
+      ssl_set_cipher_list(conf, s);
     } else if ( name == ATOM_host && arity == 1 )
     { char *s;
 
@@ -1426,6 +1434,7 @@ pl_ssl_get_socket(term_t config, term_t data)
     return FALSE;
   return PL_unify_integer(data, conf->sock);
 }
+
 
 /**
  * FIXME: if anything goes wrong, the instance is not reclaimed.
@@ -1843,6 +1852,7 @@ install_ssl4pl(void)
   ATOM_cert_verify_hook   = PL_new_atom("cert_verify_hook");
   ATOM_close_parent       = PL_new_atom("close_parent");
   ATOM_disable_ssl_methods= PL_new_atom("disable_ssl_methods");
+  ATOM_cipher_list	  = PL_new_atom("cipher_list");
   ATOM_root_certificates  = PL_new_atom("root_certificates");
   ATOM_sslv2              = PL_new_atom("sslv2");
   ATOM_sslv23             = PL_new_atom("sslv23");

--- a/ssllib.h
+++ b/ssllib.h
@@ -106,6 +106,7 @@ typedef struct pl_ssl {
     char *              pl_ssl_cacert;
     char *              pl_ssl_certf;
     char *              pl_ssl_keyf;
+    char *		pl_ssl_cipher_list;
     X509_crl_list *     pl_ssl_crl_list;
     char *              pl_ssl_password;
     BOOL                pl_ssl_cert_required;
@@ -175,6 +176,7 @@ char *          ssl_set_password (PL_SSL *config, const char *password);
 BOOL            ssl_set_cert     (PL_SSL *config, BOOL required);
 BOOL            ssl_set_crl_required(PL_SSL *config, BOOL required);
 X509_crl_list*  ssl_set_crl_list (PL_SSL *config, X509_crl_list* list);
+char *		ssl_set_cipher_list(PL_SSL *config, const char *cipher_list);
 BOOL            ssl_set_peer_cert(PL_SSL *config, BOOL required);
 BOOL		ssl_set_close_parent(PL_SSL *config, int closeparent);
 void            ssl_set_method_options(PL_SSL *config, int options);


### PR DESCRIPTION
This helps to avoid ciphers that have become obsolete.