### PR TITLE
DOC: SSL: document port/1 and host/1 options for ssl_context/3

### DIFF
--- a/ssl.doc
+++ b/ssl.doc
@@ -230,11 +230,11 @@ typically need to ensure they have a secure connection to their
 peer. To do this, first obtain a non-secure connection to the peer (eg
 via a TCP socket connection). Then create an SSL context via
 ssl_context/3. For the client initiating the connection, the role is
-'client', and you should pass options host/1, port/1 and cacert_file/1
+'client', and you should pass options host/1 and cacert_file/1
 at the very least. If you expect the peer to have a certificate which
 would be accepted by your host system, you can pass
-cacert_file(system(root_certificates)), otherwise you will need a copy
-of the CA certificate which was used to sign the peer's
+\term{cacert_file}{system(root_certificates)}, otherwise you will need
+a copy of the CA certificate which was used to sign the peer's
 certificate. Alternatively, you can pass cert_verify_hook/1 to write
 your own custom validation for the peer's certificate. Depending on
 the requirements, you may also have to provide your /own/ certificate

--- a/ssl.pl
+++ b/ssl.pl
@@ -129,6 +129,11 @@ easily be used.
 %	Prolog streams into encrypted streams.  This predicate processes
 %	the options below.
 %
+%	  * host(+HostName)
+%	  For the client, the host to which it connects. This option
+%	  _should_ be specified when Role is `client`. Otherwise,
+%	  certificate verification may fail when negotiating a
+%	  secure connection.
 %	  * certificate_file(+FileName)
 %	  Specify where the certificate file can be found. This can
 %	  be the same as the key_file(+FileName) option.  A certificate

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -48,7 +48,6 @@ static atom_t ATOM_server;
 static atom_t ATOM_client;
 static atom_t ATOM_password;
 static atom_t ATOM_host;
-static atom_t ATOM_port;
 static atom_t ATOM_cert;
 static atom_t ATOM_peer_cert;
 static atom_t ATOM_cacert_file;
@@ -1225,13 +1224,6 @@ pl_ssl_context(term_t role, term_t config, term_t options, term_t method)
 	return FALSE;
 
       ssl_set_host(conf, s);
-    } else if ( name == ATOM_port && arity == 1 )
-    { int p;
-
-      if ( !get_int_arg(1, head, &p) )
-	return FALSE;
-
-      ssl_set_port(conf, p);
     } else if ( name == ATOM_cert && arity == 1 )
     { int val;
 
@@ -2135,7 +2127,6 @@ install_ssl4pl(void)
   ATOM_client             = PL_new_atom("client");
   ATOM_password           = PL_new_atom("password");
   ATOM_host               = PL_new_atom("host");
-  ATOM_port               = PL_new_atom("port");
   ATOM_cert               = PL_new_atom("cert");
   ATOM_peer_cert          = PL_new_atom("peer_cert");
   ATOM_cacert_file        = PL_new_atom("cacert_file");

--- a/ssllib.c
+++ b/ssllib.c
@@ -329,7 +329,6 @@ ssl_new(void)
 
         new->use_system_cacert          = FALSE;
         new->pl_ssl_host                = NULL;
-        new->pl_ssl_port                = -1;
 
         new->pl_ssl_cacert              = NULL;
         new->pl_ssl_cert_required       = FALSE;
@@ -549,15 +548,6 @@ ssl_set_host(PL_SSL *config, const char *host)
         config->pl_ssl_host = ssl_strdup(host);
     }
     return config->pl_ssl_host;
-}
-
-int
-ssl_set_port(PL_SSL *config, int port)
-/*
- * Store supplied port in config storage
- */
-{
-    return config->pl_ssl_port = port;
 }
 
 BOOL

--- a/ssllib.h
+++ b/ssllib.h
@@ -92,12 +92,9 @@ typedef struct pl_ssl {
     X509 *              pl_ssl_peer_cert;
 
     /*
-     * In case of the server the hosts we're accepting (NULL for any),
-     * in case of the client the host we're connecting to.
-     * We also store the socket file descriptor.
+     * In case of the client the host we're connecting to.
      */
     char *              pl_ssl_host;
-    int                 pl_ssl_port;
 
     /*
      * Various parameters affecting the SSL layer


### PR DESCRIPTION
This is the reason for #21 : `host/1` and `port/1` were not specified (because they were not documented).