### PR TITLE
FIXED: HTTPS: Avoid leaking file descriptor after failed TLS negotation.

### DIFF
--- a/http_ssl_plugin.pl
+++ b/http_ssl_plugin.pl
@@ -149,7 +149,7 @@ ssl_protocol_hook(Parts, PlainStreamPair, StreamPair, Options) :-
         stream_pair(PlainStreamPair, PlainIn, PlainOut),
         catch(ssl_negotiate(SSL, PlainIn, PlainOut, In, Out),
               Exception,
-              ( ssl_exit(SSL), throw(Exception)) ),
+              ( close(PlainStreamPair), throw(Exception)) ),
         stream_pair(StreamPair, In, Out).
 
 %%	http:open_options(Parts, Options) is nondet.

--- a/http_ssl_plugin.pl
+++ b/http_ssl_plugin.pl
@@ -3,7 +3,7 @@
     Author:        Jan Wielemaker
     E-mail:        J.Wielemaker@vu.nl
     WWW:           http://www.swi-prolog.org
-    Copyright (c)  2007-2015, University of Amsterdam
+    Copyright (c)  2007-2016, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.
 
@@ -147,9 +147,8 @@ ssl_protocol_hook(Parts, PlainStreamPair, StreamPair, Options) :-
 				 | Options
 				 ]),
         stream_pair(PlainStreamPair, PlainIn, PlainOut),
-        catch(ssl_negotiate(SSL, PlainIn, PlainOut, In, Out),
-              Exception,
-              ( close(PlainStreamPair), throw(Exception)) ),
+        % if an exception arises, http_open/3 closes the stream for us
+        ssl_negotiate(SSL, PlainIn, PlainOut, In, Out),
         stream_pair(StreamPair, In, Out).
 
 %%	http:open_options(Parts, Options) is nondet.


### PR DESCRIPTION
Two issues must be distinguished here:
1. `ssl_exit/1` was a no-op here, because `ssl_context/3` is used instead of
   the (now deprecated) `ssl_init/3` to initialize the connection
2. if the TLS negotiation failed, then the exception was thrown but the
   plain stream was not closed.

A test case for this is to start the example server with:

```
$ swipl -g server server.pl
```

and then run the following query from a different Prolog process:

```
?- repeat,
   catch(http_open('https://localhost:1111', Stream, []), _, true),
   false.
```

In this case, TLS negotiation always fails (because the certificate
cannot be verified; also, no client certificate is specified).

Without this patch, running the query leaks file descriptors.
