### PR TITLE
Corrections and improvements to the SSL server and client examples

### DIFF
--- a/client.pl
+++ b/client.pl
@@ -57,8 +57,7 @@ client_loop(In, Out) :-
 	write_server(In, Out),
 	write_server(In, Out),
 	write_server(In, Out),
-	close(In),
-	close(Out).
+	call_cleanup(close(In), close(Out)).
 
 write_server(In, Out) :-
 	format(Out, 'Hello~n', ''),

--- a/client.pl
+++ b/client.pl
@@ -41,7 +41,6 @@
 client :-
 	ssl_context(client, SSL,
 		 [ host('localhost'),
-		   peer_cert(true),
 		   cacert_file('etc/demoCA/cacert.pem'),
 		   certificate_file('etc/client/client-cert.pem'),
 		   key_file('etc/client/client-key.pem'),

--- a/client.pl
+++ b/client.pl
@@ -42,7 +42,6 @@ client :-
 	ssl_init(SSL, client,
 		 [ host('localhost'),
                    port(1111),
-                   cert(true),
                    peer_cert(true),
 		   cacert_file('etc/demoCA/cacert.pem'),
 		   certificate_file('etc/client/client-cert.pem'),

--- a/client.pl
+++ b/client.pl
@@ -45,6 +45,7 @@ client :-
 		   cacert_file('etc/demoCA/cacert.pem'),
 		   certificate_file('etc/client/client-cert.pem'),
 		   key_file('etc/client/client-key.pem'),
+		   close_parent(true),
 %		   password('apenoot2'),
 		   pem_password_hook(get_client_pwd)
 		 ]),

--- a/client.pl
+++ b/client.pl
@@ -52,7 +52,9 @@ client :-
 	Port = 1111,
 	tcp_connect(localhost:Port, StreamPair, []),
 	stream_pair(StreamPair, Read, Write),
-	ssl_negotiate(SSL, Read, Write, SSLRead, SSLWrite),
+	catch(ssl_negotiate(SSL, Read, Write, SSLRead, SSLWrite),
+	      E,
+	      ( close(StreamPair), throw(E))),
 	client_loop(SSLRead, SSLWrite).
 
 client_loop(In, Out) :-

--- a/client.pl
+++ b/client.pl
@@ -41,6 +41,7 @@
 client :-
 	ssl_context(client, SSL,
 		 [ host('localhost'),
+		   cert_verify_hook(cert_verify),
 		   cacert_file('etc/demoCA/cacert.pem'),
 		   certificate_file('etc/client/client-cert.pem'),
 		   key_file('etc/client/client-key.pem'),
@@ -71,3 +72,7 @@ write_server(In, Out) :-
 user:get_client_pwd(_SSL, apenoot2) :-
 	format('Returning password from client passwd hook~n').
 
+cert_verify(_SSL, Certificate, _AllCerts, _FirstCert, Error) :-
+	format('Handling detailed certificate verification~n'),
+	format('Certificate: ~w, error: ~w~n', [Certificate, Error]),
+	format('Client accepts the server certificate~n').

--- a/server.pl
+++ b/server.pl
@@ -61,10 +61,15 @@ server_loop(SSL, Server) :-
 	tcp_accept(Server, Socket, Peer),
 	tcp_open_socket(Socket, Read, Write),
 	debug(connection, 'Connection from ~p', [Peer]),
-	ssl_negotiate(SSL, Read, Write, SSLRead, SSLWrite),
-	copy_client(SSLRead, SSLWrite),
-	close(SSLRead),
-	close(SSLWrite),
+	catch(ssl_negotiate(SSL, Read, Write, SSLRead, SSLWrite),
+	      Exception,
+	      true),
+	(   nonvar(Exception) ->
+	    format("Exception during negotation: ~w~n", [Exception])
+	;   copy_client(SSLRead, SSLWrite),
+	    close(SSLRead),
+	    close(SSLWrite)
+	),
 	server_loop(SSL, Server).
 
 copy_client(In, Out) :-

--- a/server.pl
+++ b/server.pl
@@ -44,7 +44,6 @@ server :-
 	ssl_init(SSL, server,
 		 [ host('localhost'),
                    port(1111),
-                   cert(true),
                    peer_cert(true),
 		   cacert_file('etc/demoCA/cacert.pem'),
 		   certificate_file('etc/server/server-cert.pem'),

--- a/server.pl
+++ b/server.pl
@@ -64,11 +64,10 @@ server_loop(SSL, Server) :-
 	catch(ssl_negotiate(SSL, Read, Write, SSLRead, SSLWrite),
 	      Exception,
 	      true),
-	(   nonvar(Exception) ->
-	    format("Exception during negotation: ~w~n", [Exception])
+	(   nonvar(Exception)
+	->  format("Exception during negotation: ~w~n", [Exception])
 	;   copy_client(SSLRead, SSLWrite),
-	    close(SSLRead),
-	    close(SSLWrite)
+	    call_cleanup(close(SSLRead), close(SSLWrite))
 	),
 	server_loop(SSL, Server).
 

--- a/server.pl
+++ b/server.pl
@@ -76,7 +76,7 @@ copy_client(In, Out) :-
 get_server_pwd(_SSL, apenoot1) :-
 	format('Returning password from server passwd hook~n').
 
-get_cert_verify(_SSL, Certificate, Error) :-
+get_cert_verify(_SSL, Certificate, _AllCerts, _FirstCert, Error) :-
 	format('Handling detailed certificate verification~n'),
 	format('Certificate: ~w, error: ~w~n', [Certificate, Error]),
 	format('Server accepts the client certificate~n').


### PR DESCRIPTION
Most importantly, these changes make the client and server examples **work** _at all_ (again).

Second, the **new interface** predicates of `library(ssl)` are now being used.

Third, resource handling is improved.

Finally, the removal of superfluous options has led to small simplifications.

Note that correcting #30 is necessary to try the examples, with _and_ without this pull request.
