### PR TITLE
ADDED: key/1 option to specify a private key as obtained by load_priv…

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -147,6 +147,10 @@ easily be used.
 %	  be found.  If the key is encrypted with a password, this must
 %	  be supplied using the password(+Text) or
 %	  =|pem_password_hook(:PredicateName)|= option.
+%	  * key(+PrivateKey)
+%	  PrivateKey is the private key as obtained by load_private_key/3.
+%	  This option provides an alternative method to specify
+%	  a private key, in addition to the key_file/1 option.
 %	  * password(+Text)
 %	  Specify the password the private key is protected with (if
 %	  any). If you do not want to store the password you can also

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -61,6 +61,7 @@ static atom_t ATOM_close_parent;
 static atom_t ATOM_disable_ssl_methods;
 static atom_t ATOM_cipher_list;
 static atom_t ATOM_ecdh_curve;
+static atom_t ATOM_key;
 static atom_t ATOM_root_certificates;
 
 static atom_t ATOM_sslv2;
@@ -1270,6 +1271,16 @@ pl_ssl_context(term_t role, term_t config, term_t options, term_t method)
 	return FALSE;
 
       ssl_set_keyf(conf, file);
+    } else if ( name == ATOM_key && arity == 1 )
+    { term_t key_arg;
+      RSA* key;
+
+      if ( ( key_arg = PL_new_term_ref() ) &&
+	   PL_get_arg(1, head, key_arg ) &&
+	   recover_private_key(key_arg, &key) )
+	ssl_set_key(conf, key);
+      else
+	return FALSE;
     } else if ( name == ATOM_pem_password_hook && arity == 1 )
     { predicate_t hook;
 
@@ -2106,6 +2117,7 @@ install_ssl4pl(void)
   ATOM_cacert_file        = PL_new_atom("cacert_file");
   ATOM_certificate_file   = PL_new_atom("certificate_file");
   ATOM_key_file           = PL_new_atom("key_file");
+  ATOM_key                = PL_new_atom("key");
   ATOM_pem_password_hook  = PL_new_atom("pem_password_hook");
   ATOM_cert_verify_hook   = PL_new_atom("cert_verify_hook");
   ATOM_close_parent       = PL_new_atom("close_parent");

--- a/ssllib.c
+++ b/ssllib.c
@@ -312,14 +312,20 @@ ssl_rsadup(const RSA *rsa)
 {
     RSA *c = RSA_new();
 
-    c->n = rsa->n;
-    c->e = rsa->e;
-    c->d = rsa->d;
-    c->p = rsa->p;
-    c->q = rsa->q;
-    c->dmp1 = rsa->dmp1;
-    c->dmq1 = rsa->dmq1;
-    c->iqmp = rsa->iqmp;
+    if (c != NULL) {
+      c->n = BN_dup(rsa->n);
+      c->e = BN_dup(rsa->e);
+      c->d = BN_dup(rsa->d);
+      c->p = BN_dup(rsa->p);
+      c->q = BN_dup(rsa->q);
+      c->dmp1 = BN_dup(rsa->dmp1);
+      c->dmq1 = BN_dup(rsa->dmq1);
+      c->iqmp = BN_dup(rsa->iqmp);
+    }
+
+    if (c->n == NULL || c->e == NULL || c->d == NULL || c->p == NULL ||
+        c->q == NULL || c->dmp1 == NULL || c->dmq1 == NULL || c->iqmp == NULL)
+      return NULL;
 
     return c;
 }

--- a/ssllib.h
+++ b/ssllib.h
@@ -3,7 +3,7 @@
     Author:        Jan van der Steen and Jan Wielemaker
     E-mail:        J.van.der.Steen@diff.nl and jan@swi.psy.uva.nl
     WWW:           http://www.swi-prolog.org
-    Copyright (c)  2004-2015, SWI-Prolog Foundation
+    Copyright (c)  2004-2016, SWI-Prolog Foundation
                               VU University Amsterdam
     All rights reserved.
 
@@ -103,6 +103,7 @@ typedef struct pl_ssl {
     char *              pl_ssl_cacert;
     char *              pl_ssl_certf;
     char *              pl_ssl_keyf;
+    RSA  *              pl_ssl_key;
     char *              pl_ssl_cipher_list;
     char *              pl_ssl_ecdh_curve;
     X509_crl_list *     pl_ssl_crl_list;
@@ -170,6 +171,7 @@ char *          ssl_set_cacert   (PL_SSL *config, const char *cacert);
 int             ssl_set_use_system_cacert(PL_SSL *config, int use_system_cacert);
 char *          ssl_set_certf    (PL_SSL *config, const char *certf);
 char *          ssl_set_keyf     (PL_SSL *config, const char *keyf);
+RSA  *          ssl_set_key      (PL_SSL *config, const RSA *key);
 char *          ssl_set_password (PL_SSL *config, const char *password);
 BOOL            ssl_set_cert     (PL_SSL *config, BOOL required);
 BOOL            ssl_set_crl_required(PL_SSL *config, BOOL required);


### PR DESCRIPTION
…ate_key/3.

This is in preparation for letting the HTTP Unix daemon read private keys
as root, before dropping privileges.