### PR TITLE
ADDED: certificate/1 option to specify the certificate chain as an atom.

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -140,8 +140,12 @@ easily be used.
 %	  file is obligatory for a server and may be provided for a
 %	  client if the server demands the client to identify itself
 %	  with a client certificate using the peer_cert(true) option. If
-%	  a certificate is provided, it is always necessary to provide a
-%	  matching _private key_ using the key_file(+FileName) option.
+%	  a certificate is provided, it is necessary to also provide a
+%	  matching _private key_ via the key_file/1 or key/1 options.
+%	  * certificate(+Atom)
+%	  Alternative method for specifying the certificate. The argument
+%	  is an atom or string that holds the PEM-encoded certificate,
+%	  and possibly further certificates of the chain.
 %	  * key_file(+FileName)
 %	  Specify where the private key that matches the certificate can
 %	  be found.  If the key is encrypted with a password, this must

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -54,6 +54,7 @@ static atom_t ATOM_cacert_file;
 static atom_t ATOM_require_crl;
 static atom_t ATOM_crl;
 static atom_t ATOM_certificate_file;
+static atom_t ATOM_certificate;
 static atom_t ATOM_key_file;
 static atom_t ATOM_pem_password_hook;
 static atom_t ATOM_cert_verify_hook;
@@ -1264,6 +1265,13 @@ pl_ssl_context(term_t role, term_t config, term_t options, term_t method)
 	return FALSE;
 
       ssl_set_certf(conf, file);
+    } else if ( name == ATOM_certificate && arity == 1 )
+    { char *s;
+
+      if ( !get_char_arg(1, head, &s) )
+	return FALSE;
+
+      ssl_set_certificate(conf, s);
     } else if ( name == ATOM_key_file && arity == 1 )
     { char *file;
 
@@ -2117,6 +2125,7 @@ install_ssl4pl(void)
   ATOM_peer_cert          = PL_new_atom("peer_cert");
   ATOM_cacert_file        = PL_new_atom("cacert_file");
   ATOM_certificate_file   = PL_new_atom("certificate_file");
+  ATOM_certificate        = PL_new_atom("certificate");
   ATOM_key_file           = PL_new_atom("key_file");
   ATOM_key                = PL_new_atom("key");
   ATOM_pem_password_hook  = PL_new_atom("pem_password_hook");

--- a/ssllib.h
+++ b/ssllib.h
@@ -102,6 +102,7 @@ typedef struct pl_ssl {
     int                 use_system_cacert;
     char *              pl_ssl_cacert;
     char *              pl_ssl_certf;
+    char *              pl_ssl_certificate;
     char *              pl_ssl_keyf;
     RSA  *              pl_ssl_key;
     char *              pl_ssl_cipher_list;
@@ -170,6 +171,7 @@ int             ssl_set_port     (PL_SSL *config, int port);
 char *          ssl_set_cacert   (PL_SSL *config, const char *cacert);
 int             ssl_set_use_system_cacert(PL_SSL *config, int use_system_cacert);
 char *          ssl_set_certf    (PL_SSL *config, const char *certf);
+char *          ssl_set_certificate(PL_SSL *config, const char *cert);
 char *          ssl_set_keyf     (PL_SSL *config, const char *keyf);
 RSA  *          ssl_set_key      (PL_SSL *config, const RSA *key);
 char *          ssl_set_password (PL_SSL *config, const char *password);


### PR DESCRIPTION
This is added to let the HTTP Unix daemon read the certificate before
dropping privileges.