### PR TITLE
Server Name Indication (SNI) for the SSL server

### DIFF
--- a/ssl.doc
+++ b/ssl.doc
@@ -387,9 +387,10 @@ visible. It is not needed to decrypt the traffic using port forwarding,
 but it is also not possible to realise \jargon{virtual hosts} or
 \jargon{path-based} proxy rules.
 
-There is a TLS~extension called \jargon{Server Name Indication}~(SNI)
-which allows virtual hosts for~HTTPS. However, server-side~SNI is
-currently not implemented by this~library.
+Virtual hosts for HTTPS are available via \jargon{Server Name
+  Indication}~(SNI). This is a TLS extension that allows servers to
+host different domains from the same IP address. See the sni_hook/1
+option of ssl_context/3 for more information.
 
 \section{Acknowledgments}
 \label{sec:ssl-acknowledgments}

--- a/ssl.pl
+++ b/ssl.pl
@@ -247,11 +247,13 @@ easily be used.
 %	  call(PredicateName, +SSL0, +HostName, -SSL)
 %	  ==
 %
-%	  Given the current context SSL0, and the host name of the client
-%	  request, the predicate computes SSL which is used as the
-%	  context for negotiating the connection. The first solution is
-%	  used.  If the predicate fails, the default options are used,
-%	  which are those of the encompassing ssl_context/3 call.
+%	  Given the current context SSL0, and the host name of the
+%	  client request, the predicate computes SSL which is used as
+%	  the context for negotiating the connection. The first solution
+%	  is used.  If the predicate fails, the default options are
+%	  used, which are those of the encompassing ssl_context/3
+%	  call. In that case, if no default certificate and key are
+%	  specified, the client connection is rejected.
 %
 %	@arg Role is one of `server` or `client` and denotes whether the
 %	SSL  instance  will  have  a  server   or  client  role  in  the

--- a/ssl.pl
+++ b/ssl.pl
@@ -234,6 +234,24 @@ easily be used.
 %	  * ssl_method(+Method)
 %	  Specify the explicit Method to use when negotiating. For
 %	  allowed values, see the list for `disable_ssl_methods` above.
+%	  * sni_hook(+PredicateName)
+%	  This option provides Server Name Indication (SNI) for SSL
+%	  servers. This means that depending on the host to which a
+%	  client connects, different options (certificates etc.) can
+%	  be used for the server. This TLS extension allows you to host
+%	  different domains using the same IP address and physical
+%	  machine. When a TLS connection is negotiated, the hook is
+%	  called as follows:
+%
+%	  ==
+%	  call(PredicateName, +SSL0, +HostName, -SSL)
+%	  ==
+%
+%	  Given the current context SSL0, and the host name of the client
+%	  request, the predicate computes SSL which is used as the
+%	  context for negotiating the connection. The first solution is
+%	  used.  If the predicate fails, the default options are used,
+%	  which are those of the encompassing ssl_context/3 call.
 %
 %	@arg Role is one of `server` or `client` and denotes whether the
 %	SSL  instance  will  have  a  server   or  client  role  in  the

--- a/ssllib.c
+++ b/ssllib.c
@@ -942,6 +942,7 @@ ssl_set_cb_sni(PL_SSL *config,
   return TRUE;
 }
 
+#ifndef OPENSSL_NO_TLSEXT
 static int
 ssl_cb_sni(SSL *s, int *ad, void *arg)
 {
@@ -956,6 +957,8 @@ ssl_cb_sni(SSL *s, int *ad, void *arg)
 
   return SSL_TLSEXT_ERR_OK;
 }
+#endif
+
 
 BOOL
 ssl_set_close_parent(PL_SSL *config, int closeparent)
@@ -1534,12 +1537,14 @@ ssl_config(PL_SSL *config, term_t options)
 			    ssl_cb_cert_verify);
   ssl_deb(1, "installed certificate verification handler\n");
 
+#ifndef OPENSSL_NO_TLSEXT
   if ( config->pl_ssl_role == PL_SSL_SERVER &&
        config->pl_ssl_cb_sni_data ) {
     SSL_CTX_set_tlsext_servername_callback(config->pl_ssl_ctx, ssl_cb_sni);
     SSL_CTX_set_tlsext_servername_arg(config->pl_ssl_ctx, config);
     ssl_deb(1, "installed SNI callback\n");
   }
+#endif
 
   return TRUE;
 }
@@ -1800,7 +1805,9 @@ ssl_ssl_bio(PL_SSL *config, IOSTREAM* sread, IOSTREAM* swrite,
 
   if ( config->pl_ssl_role == PL_SSL_CLIENT )
   { if ( config->pl_ssl_host )
+#ifndef OPENSSL_NO_TLSEXT
       SSL_set_tlsext_host_name(instance->ssl, config->pl_ssl_host);
+#endif
 #ifdef HAVE_X509_CHECK_HOST
     X509_VERIFY_PARAM *param = SSL_get0_param(instance->ssl);
     /* This could in theory be user-configurable. The documentation at

--- a/ssllib.c
+++ b/ssllib.c
@@ -356,6 +356,7 @@ ssl_new(void)
         new->pl_ssl_cert_required       = FALSE;
         new->pl_ssl_certf               = NULL;
         new->pl_ssl_certificate         = NULL;
+        new->pl_ssl_certificate_X509    = NULL;
         new->pl_ssl_keyf                = NULL;
         new->pl_ssl_key                 = NULL;
         new->pl_ssl_cipher_list         = NULL;
@@ -397,6 +398,8 @@ ssl_free(PL_SSL *config)
     free(config->pl_ssl_cipher_list);
     free(config->pl_ssl_ecdh_curve);
     free_X509_crl_list(config->pl_ssl_crl_list);
+    if ( config->pl_ssl_certificate_X509 )
+      X509_free(config->pl_ssl_certificate_X509);
     free(config->pl_ssl_password);
     if ( config->pl_ssl_peer_cert )
       X509_free(config->pl_ssl_peer_cert);
@@ -1484,6 +1487,8 @@ ssl_config(PL_SSL *config, term_t options)
       certX509 = PEM_read_bio_X509(bio, NULL, NULL, NULL);
       if ( !certX509 )
         return raise_ssl_error(ERR_get_error());
+
+      config->pl_ssl_certificate_X509 = certX509;
 
       if ( SSL_CTX_use_certificate(config->pl_ssl_ctx, certX509) <= 0 )
         return raise_ssl_error(ERR_get_error());

--- a/ssllib.h
+++ b/ssllib.h
@@ -128,6 +128,8 @@ typedef struct pl_ssl {
                                                 , int
                                                 ) ;
     void *              pl_ssl_cb_pem_passwd_data;
+    struct pl_ssl *     (*pl_ssl_cb_sni)(struct pl_ssl *, const char*);
+    void *              pl_ssl_cb_sni_data;
 #ifndef HAVE_X509_CHECK_HOST
     int                 hostname_check_status;
 #endif
@@ -177,7 +179,7 @@ RSA  *          ssl_set_key      (PL_SSL *config, const RSA *key);
 char *          ssl_set_password (PL_SSL *config, const char *password);
 BOOL            ssl_set_cert     (PL_SSL *config, BOOL required);
 BOOL            ssl_set_crl_required(PL_SSL *config, BOOL required);
-X509_crl_list*  ssl_set_crl_list (PL_SSL *config, X509_crl_list* list);
+X509_crl_list*  ssl_set_crl_list (PL_SSL *config, X509_crl_list *list);
 char *          ssl_set_cipher_list(PL_SSL *config, const char *cipher_list);
 char *          ssl_set_ecdh_curve(PL_SSL *config, const char *ecdh_curve);
 BOOL            ssl_set_peer_cert(PL_SSL *config, BOOL required);
@@ -205,6 +207,12 @@ BOOL            ssl_set_cb_pem_passwd
                                                      )
                                  , void *
                                  ) ;
+BOOL            ssl_set_cb_sni
+                                 (PL_SSL *config,
+                                  PL_SSL * (*callback)( PL_SSL *,
+                                                        const char *),
+                                  void *
+                                  );
 
 void            ssl_msg          (char *fmt, ...);
 void            ssl_err          (char *fmt, ...);

--- a/ssllib.h
+++ b/ssllib.h
@@ -103,6 +103,7 @@ typedef struct pl_ssl {
     char *              pl_ssl_cacert;
     char *              pl_ssl_certf;
     char *              pl_ssl_certificate;
+    X509 *              pl_ssl_certificate_X509;
     char *              pl_ssl_keyf;
     RSA  *              pl_ssl_key;
     char *              pl_ssl_cipher_list;


### PR DESCRIPTION
This is a **callback**-based implementation of SNI.

Conceptually, I like the callback approach a lot. Users who care about performance can precreate the required contexts.