### PR TITLE
MODIFIED: ssl_context/3: key/1 argument is now the PEM-encoded key (string or atom)

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -144,17 +144,16 @@ easily be used.
 %	  matching _private key_ via the key_file/1 or key/1 options.
 %	  * certificate(+String)
 %	  Alternative method for specifying the certificate. The argument
-%	  is a string (or atom) that holds the PEM-encoded certificate,
+%	  is a string (or an atom) that holds the PEM-encoded certificate,
 %	  and possibly further certificates of the chain.
 %	  * key_file(+FileName)
 %	  Specify where the private key that matches the certificate can
 %	  be found.  If the key is encrypted with a password, this must
 %	  be supplied using the password(+Text) or
 %	  =|pem_password_hook(:PredicateName)|= option.
-%	  * key(+PrivateKey)
-%	  PrivateKey is the private key as obtained by load_private_key/3.
-%	  This option provides an alternative method to specify
-%	  a private key, in addition to the key_file/1 option.
+%	  * key(+String)
+%	  Alternative method for specifying the private key. The argument
+%	  is a string (or an atom) that holds the PEM-encoded key.
 %	  * password(+Text)
 %	  Specify the password the private key is protected with (if
 %	  any). If you do not want to store the password you can also

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -1300,17 +1300,12 @@ pl_ssl_context(term_t role, term_t config, term_t options, term_t method)
 
       ssl_set_keyf(conf, file);
     } else if ( name == ATOM_key && arity == 1 )
-    { term_t key_arg;
-      RSA* key;
+    { char *s;
 
-      if ( ( key_arg = PL_new_term_ref() ) &&
-	   PL_get_arg(1, head, key_arg ) &&
-	   recover_private_key(key_arg, &key) )
-      { if ( !ssl_set_key(conf, key) )
-	  return PL_resource_error("memory");
-	RSA_free(key);
-      } else
+      if ( !get_char_arg(1, head, &s) )
 	return FALSE;
+
+      ssl_set_key(conf, s);
     } else if ( name == ATOM_pem_password_hook && arity == 1 )
     { predicate_t hook;
 

--- a/ssllib.h
+++ b/ssllib.h
@@ -105,7 +105,7 @@ typedef struct pl_ssl {
     char *              pl_ssl_certificate;
     X509 *              pl_ssl_certificate_X509;
     char *              pl_ssl_keyf;
-    RSA  *              pl_ssl_key;
+    char *              pl_ssl_key;
     char *              pl_ssl_cipher_list;
     char *              pl_ssl_ecdh_curve;
     X509_crl_list *     pl_ssl_crl_list;
@@ -176,7 +176,7 @@ int             ssl_set_use_system_cacert(PL_SSL *config, int use_system_cacert)
 char *          ssl_set_certf    (PL_SSL *config, const char *certf);
 char *          ssl_set_certificate(PL_SSL *config, const char *cert);
 char *          ssl_set_keyf     (PL_SSL *config, const char *keyf);
-RSA  *          ssl_set_key      (PL_SSL *config, const RSA *key);
+char *          ssl_set_key      (PL_SSL *config, const char *key);
 char *          ssl_set_password (PL_SSL *config, const char *password);
 BOOL            ssl_set_cert     (PL_SSL *config, BOOL required);
 BOOL            ssl_set_crl_required(PL_SSL *config, BOOL required);


### PR DESCRIPTION
Please consider merging this change, which is only incompatible with the immediately preceding development release (7.3.30). Very likely, the HTTP Unix daemon is the only current user of this option (pull request forthcoming).

Generalizing this option as per this pull request is important to accommodate different current and future authentication methods, and also aligns the option format with that of `certificate/1`.

In addition, handling PEM-encoded keys simplifies the code.