### PR TITLE
Port to OpenSSL 1.1.0

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -233,6 +233,11 @@ easily be used.
 %	  * ssl_method(+Method)
 %	  Specify the explicit Method to use when negotiating. For
 %	  allowed values, see the list for `disable_ssl_methods` above.
+%	  Using this option is discouraged. When using OpenSSL 1.1.0
+%	  or later, this option is ignored, and a version-flexible method
+%	  is used to negotiate the connection. Using version-specific
+%	  methods is deprecated in recent OpenSSL versions, and this
+%	  option will become obsolete and ignored in the future.
 %	  * sni_hook(+PredicateName)
 %	  This option provides Server Name Indication (SNI) for SSL
 %	  servers. This means that depending on the host to which a

--- a/ssllib.h
+++ b/ssllib.h
@@ -220,8 +220,13 @@ void            ssl_err          (char *fmt, ...);
 int		ssl_set_debug	 (int level);
 void            ssl_deb          (int level, char *fmt, ...);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 extern BIO_METHOD bio_read_functions;
 extern BIO_METHOD bio_write_functions;
+#else
+extern BIO_METHOD *bio_read_method();
+extern BIO_METHOD *bio_write_functions();
+#endif
 
 #endif
 


### PR DESCRIPTION
This is work in progress on a port of `library(ssl)` to the OpenSSL **1.1.0** API.

Since the OpenSSL API is complex enough as is, I am dropping backwards compatibility with prior versions.

I will extend this branch with any progress I make on the port, using additional commits.

I am marking commits with **TODO** where I temporarily comment out code instead of porting it. 

Currently, it compiles, but yields:

<pre>
$ swipl -g server server.pl
<b>Cannot read back application data</b>
</pre>

At this point, I'm also considering dropping OpenSSL, and switching to a different TLS&nbsp;library altogether. It may be easier to use a different library than to keep up with&nbsp;this.