### PR TITLE
PORT: Handle EOF portably, making copy_stream_data/2 etc. work in OpenSSL 1.1.0c

### DIFF
--- a/ssllib.c
+++ b/ssllib.c
@@ -1757,6 +1757,8 @@ long bio_control(BIO* bio, int cmd, long num, void* ptr)
      case BIO_CTRL_FLUSH:
         Sflush(stream);
         return 1;
+     case BIO_CTRL_EOF:
+        return Sfeof(stream);
    }
    return 0;
 }
@@ -1968,7 +1970,9 @@ ssl_read(void *handle, char *buf, size_t size)
   for(;;)
   { int rbytes = SSL_read(ssl, buf, size);
 
-    if ( rbytes == 0 ) /* EOF - error, but we handle in prolog */
+    if ( ( rbytes == 0 ) ||
+         ( (rbytes < 0) && BIO_eof(SSL_get_rbio(ssl)) ) )
+      /* EOF - error, but we handle in prolog */
       return 0;
 
     switch(ssl_inspect_status(instance, rbytes, STAT_READ))


### PR DESCRIPTION
This is necessary due to a change in behaviour of OpenSSL 1.1.0c: When
encountering EOF, SSL_read() now returns -1 instead of 0 (as it did
previously).

Note that this behaviour may change again in future versions, since it
is currently subject to debate:

   https://github.com/openssl/openssl/issues/1903

However, 1.1.0c is already published and must be accommodated, and
further, this change will remain valid even if the return value of
SSL_read() changes again, since we now explicitly check for EOF.

Test case:

    ?- http_open('https://www.metalevel.at', In, []),
       copy_stream_data(In, current_output).

Without this commit, we get with OpenSSL 1.1.0c:

    ERROR: copy_stream_data/2: I/O error in read on stream (0x2718700) (Success)