### PR TITLE
FIXED: Load library(socket) in client and server examples.

### DIFF
--- a/client.pl
+++ b/client.pl
@@ -37,6 +37,7 @@
 	  ]).
 
 :- use_module(library(ssl)).
+:- use_module(library(socket)).
 
 client :-
 	ssl_context(client, SSL,

--- a/server.pl
+++ b/server.pl
@@ -37,6 +37,7 @@
 	  ]).
 
 :- use_module(library(ssl)).
+:- use_module(library(socket)).
 
 :- debug(connection).
 


### PR DESCRIPTION
This makes the examples work also if only a subset of packages is installed.