### PR TITLE
ADDED: New option close_notify(+Boolean), making the server send

### DIFF
--- a/client.pl
+++ b/client.pl
@@ -47,6 +47,7 @@ client :-
 		   certificate_file('etc/client/client-cert.pem'),
 		   key_file('etc/client/client-key.pem'),
 		   close_parent(true),
+		   close_notify(true),
 %		   password('apenoot2'),
 		   pem_password_hook(get_client_pwd)
 		 ]),

--- a/server.pl
+++ b/server.pl
@@ -48,6 +48,7 @@ server :-
 		      certificate_file('etc/server/server-cert.pem'),
 		      key_file('etc/server/server-key.pem'),
 		      cert_verify_hook(get_cert_verify),
+		      close_notify(true),
 		      % password('apenoot1'),
 		      pem_password_hook(get_server_pwd)
 		    ]),

--- a/ssl.pl
+++ b/ssl.pl
@@ -91,7 +91,8 @@
 		       cert_verify_hook(callable),
 		       cert(boolean),
 		       peer_cert(boolean),
-		       close_parent(boolean)
+		       close_parent(boolean),
+		       close_notify(boolean)
 		     ]).
 :- predicate_options(ssl_init/3, 3, [pass_to(ssl_context/3, 3)]).
 
@@ -226,6 +227,14 @@ easily be used.
 %	  * close_parent(+Boolean)
 %	  If `true`, close the raw streams if the SSL streams are closed.
 %	  Default is `false`.
+%	  * close_notify(+Boolean)
+%	  If `true` (default is `false`), the server sends TLS
+%	  `close_notify` when closing the connection. In addition,
+%	  this mitigates _truncation attacks_: If EOF is encountered
+%	  without either side having initiated a TLS shutdown, an
+%	  exception is raised. Well-designed protocols are
+%	  self-terminating, and this attack is therefore very rarely
+%	  a concern.
 %	  * disable_ssl_methods(+List)
 %	  A list of methods to disable. Unsupported methods will be
 %	  ignored. Methods include `sslv2`, `sslv3`, `sslv23`,

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -59,6 +59,7 @@ static atom_t ATOM_key_file;
 static atom_t ATOM_pem_password_hook;
 static atom_t ATOM_cert_verify_hook;
 static atom_t ATOM_close_parent;
+static atom_t ATOM_close_notify;
 static atom_t ATOM_disable_ssl_methods;
 static atom_t ATOM_cipher_list;
 static atom_t ATOM_ecdh_curve;
@@ -1475,6 +1476,13 @@ pl_ssl_context(term_t role, term_t config, term_t options, term_t method)
         return FALSE;
 
       ssl_set_cb_sni(conf, pl_sni_hook, (void *) hook);
+    } else if ( name == ATOM_close_notify && arity == 1 )
+    { int val;
+
+      if ( !get_bool_arg(1, head, &val) )
+	return FALSE;
+
+      ssl_set_close_notify(conf, val);
     } else
       continue;
   }
@@ -2299,6 +2307,7 @@ install_ssl4pl(void)
   ATOM_pem_password_hook  = PL_new_atom("pem_password_hook");
   ATOM_cert_verify_hook   = PL_new_atom("cert_verify_hook");
   ATOM_close_parent       = PL_new_atom("close_parent");
+  ATOM_close_notify       = PL_new_atom("close_notify");
   ATOM_disable_ssl_methods= PL_new_atom("disable_ssl_methods");
   ATOM_cipher_list        = PL_new_atom("cipher_list");
   ATOM_ecdh_curve         = PL_new_atom("ecdh_curve");

--- a/ssllib.h
+++ b/ssllib.h
@@ -84,6 +84,8 @@ typedef struct pl_ssl {
     int			sock;		/* the listening/connected socket */
     int                 closeparent;
     atom_t              atom;
+    BOOL                close_notify;
+
     /*
      * Context, Certificate, SSL info
      */
@@ -185,6 +187,7 @@ char *          ssl_set_cipher_list(PL_SSL *config, const char *cipher_list);
 char *          ssl_set_ecdh_curve(PL_SSL *config, const char *ecdh_curve);
 BOOL            ssl_set_peer_cert(PL_SSL *config, BOOL required);
 BOOL		ssl_set_close_parent(PL_SSL *config, int closeparent);
+BOOL            ssl_set_close_notify(PL_SSL *config, BOOL close_notify);
 void            ssl_set_method_options(PL_SSL *config, int options);
 int		raise_ssl_error(long e);
 X509_list *	system_root_certificates(void);


### PR DESCRIPTION
       close_notify when closing the connection.

In addition, enabling this option raises an exception when EOF is
encountered without either side having initiated a TLS shutdown. This
mitigates truncation attacks, in which an adversary may cut the
connection or inject TCP FIN packets to simulate EOF.

This attack only applies to protocols that are *not* self-terminating
and is therefore extremely rare in practice (well-designed protocols
are self-terminating). However, the client/server examples are of this
type, and therefore this option is now enabled in the examples.