### PR TITLE
ENHANCED: Use OpenSSL default curves (ecdh_curve/1) in OpenSSL >= 1.1.0.

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -214,7 +214,9 @@ easily be used.
 %	  Specify a cipher preference list (one or more cipher strings
 %	  separated by colons, commas or spaces).
 %	  * ecdh_curve(+Atom)
-%	  Specify a curve for ECDHE ciphers. The default is `prime256v1`.
+%	  Specify a curve for ECDHE ciphers. If this option is not
+%	  specified, the OpenSSL default parameters are used.  With
+%	  OpenSSL prior to 1.1.0, `prime256v1` is used by default.
 %	  * cert(+Boolean)
 %	  Trigger the sending of our certificate specified by
 %	  certificate_file(FileName).  Sending is automatic for the


### PR DESCRIPTION
Earlier OpenSSL versions do not set a curve by default. We use
prime256v1 in such cases, as before, but no longer override the new
library defaults with this curve.

This commit makes stronger curves automatically available when using
newer OpenSSL versions, unless users have explicitly asked for a
specific curve. A major attraction of OpenSSL 1.1.0 is X25519, which
is the new default curve in that version for ECDH.

To disable ECDH entirely, use the cipher_list/1 option (also as before).

In the future, ecdh_curve/1 will be superseded by a new option that
binds SSL_CTX_set1_groups. However, this currently affects both ECDH
and ECDSA, and we will adopt the eventual solution of OpenSSL.

See https://github.com/openssl/openssl/issues/2033 for more information.