### PR TITLE
PORT: Allow compilation when OpenSSL 1.1.0 is compiled with "no-deprecated"

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -105,6 +105,7 @@ AC_CHECK_FUNCS(X509_check_host)
 AC_CHECK_FUNCS(CRYPTO_THREADID_get_callback CRYPTO_THREADID_set_callback)
 AC_CHECK_FUNCS(EVP_MD_CTX_free OPENSSL_zalloc)
 AC_CHECK_FUNCS(X509_CRL_get0_signature X509_get0_signature)
+AC_CHECK_FUNCS(X509_get0_notBefore X509_get0_notAfter)
 
 if test "x$ac_cv_func_X509_get0_signature" = "xyes"; then
   ac_oldcflags="$CFLAGS"

--- a/configure.in
+++ b/configure.in
@@ -106,6 +106,7 @@ AC_CHECK_FUNCS(CRYPTO_THREADID_get_callback CRYPTO_THREADID_set_callback)
 AC_CHECK_FUNCS(EVP_MD_CTX_free OPENSSL_zalloc)
 AC_CHECK_FUNCS(X509_CRL_get0_signature X509_get0_signature)
 AC_CHECK_FUNCS(X509_get0_notBefore X509_get0_notAfter)
+AC_CHECK_FUNCS(OpenSSL_version)
 
 if test "x$ac_cv_func_X509_get0_signature" = "xyes"; then
   ac_oldcflags="$CFLAGS"

--- a/configure.in
+++ b/configure.in
@@ -107,6 +107,7 @@ AC_CHECK_FUNCS(EVP_MD_CTX_free OPENSSL_zalloc)
 AC_CHECK_FUNCS(X509_CRL_get0_signature X509_get0_signature)
 AC_CHECK_FUNCS(X509_get0_notBefore X509_get0_notAfter)
 AC_CHECK_FUNCS(OpenSSL_version)
+AC_CHECK_FUNCS(EVP_CIPHER_CTX_reset)
 
 if test "x$ac_cv_func_X509_get0_signature" = "xyes"; then
   ac_oldcflags="$CFLAGS"

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -2404,7 +2404,13 @@ install_ssl4pl(void)
   (void) ssl_lib_init();
 
   PL_set_prolog_flag("ssl_library_version", PL_ATOM,
-		     SSLeay_version(SSLEAY_VERSION));
+#ifdef HAVE_OPENSSL_VERSION
+		     OpenSSL_version(OPENSSL_VERSION)
+#else
+		     SSLeay_version(SSLEAY_VERSION)
+#endif
+		     );
+
   PL_set_prolog_flag("system_cacert_filename", PL_ATOM,
 		     SYSTEM_CACERT_FILENAME);
 }

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -2180,6 +2180,9 @@ pl_ssl_peer_certificate(term_t stream_t, term_t Cert)
   return FALSE;
 }
 
+#ifndef HAVE_EVP_CIPHER_CTX_RESET
+#define EVP_CIPHER_CTX_reset(C) EVP_CIPHER_CTX_init(C)
+#endif
 
 static foreign_t
 pl_evp_decrypt(term_t ciphertext_t, term_t algorithm_t,
@@ -2212,7 +2215,7 @@ pl_evp_decrypt(term_t ciphertext_t, term_t algorithm_t,
   if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
     return FALSE;
 
-  EVP_CIPHER_CTX_init(ctx);
+  EVP_CIPHER_CTX_reset(ctx);
   EVP_DecryptInit_ex(ctx, cipher, NULL,
 		     (const unsigned char*)key, (const unsigned char*)iv);
   EVP_CIPHER_CTX_set_padding(ctx, padding);
@@ -2267,7 +2270,7 @@ pl_evp_encrypt(term_t plaintext_t, term_t algorithm_t,
   if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
     return FALSE;
 
-  EVP_CIPHER_CTX_init(ctx);
+  EVP_CIPHER_CTX_reset(ctx);
   EVP_EncryptInit_ex(ctx, cipher, NULL,
 		     (const unsigned char*)key, (const unsigned char*)iv);
 

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -748,6 +748,12 @@ unify_private_key(EVP_PKEY* key, term_t item)
 { return unify_key(key, FUNCTOR_private_key1, item);
 }
 
+#ifndef HAVE_X509_GET0_NOTBEFORE
+#define X509_get0_notBefore(C) X509_get_notBefore(C)
+#endif
+#ifndef HAVE_X509_GET0_NOTAFTER
+#define X509_get0_notAfter(C) X509_get_notAfter(C)
+#endif
 
 static int
 unify_certificate(term_t cert, X509* data)
@@ -778,7 +784,7 @@ unify_certificate(term_t cert, X509* data)
      return FALSE;
   if (!(PL_unify_list(list, item, list) &&
         (not_before = PL_new_term_ref()) &&
-        unify_asn1_time(not_before, X509_get_notBefore(data)) &&
+        unify_asn1_time(not_before, X509_get0_notBefore(data)) &&
         PL_unify_term(item,
                       PL_FUNCTOR, FUNCTOR_notbefore1,
                       PL_TERM, not_before)))
@@ -786,7 +792,7 @@ unify_certificate(term_t cert, X509* data)
 
   if (!(PL_unify_list(list, item, list) &&
         (not_after = PL_new_term_ref()) &&
-        unify_asn1_time(not_after, X509_get_notAfter(data)) &&
+        unify_asn1_time(not_after, X509_get0_notAfter(data)) &&
         PL_unify_term(item,
                       PL_FUNCTOR, FUNCTOR_notafter1,
                       PL_TERM, not_after)))

--- a/ssllib.c
+++ b/ssllib.c
@@ -1093,7 +1093,9 @@ ssl_close(PL_SSL_INSTANCE *instance)
 
         free(instance);
     }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     ERR_free_strings();
+#endif
 
     ssl_deb(1, "Controlled close\n");
     return ret;

--- a/ssllib.c
+++ b/ssllib.c
@@ -1695,12 +1695,12 @@ ssl_lib_init(void)
  * One-time library initialization code
  */
 {
-    SSL_load_error_strings();
     /* This call will ensure we only end up calling RAND_poll() once
        - preventing an ugly synchronization issue in OpenSSL */
     RAND_status();
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     (void) SSL_library_init();
+    SSL_load_error_strings();
 #else
     (void) OPENSSL_init_ssl(0, NULL);
 #endif

--- a/ssllib.h
+++ b/ssllib.h
@@ -60,6 +60,12 @@ typedef enum
 #include <openssl/x509v3.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/bn.h>
+#include <openssl/evp.h>
+#include <openssl/dh.h>
+#include <openssl/rsa.h>
+#include <openssl/dsa.h>
+#include <openssl/x509.h>
 
 typedef struct X509_list
 { struct X509_list *next;


### PR DESCRIPTION
This uses aliases where necessary to retain compatibility with old OpenSSL versions.