### PR TITLE
ADDED: library(crypto)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -86,11 +86,13 @@ clientcert:
 # Documentation
 ################################################################
 
-TEXEXTRA=	ssllib.tex saml.tex xmldsig.tex xmlenc.tex
+TEXEXTRA=	ssllib.tex crypto.tex saml.tex xmldsig.tex xmlenc.tex
 $(TEX):		$(TEXEXTRA)
 
 ssllib.tex:	ssl.pl
 		$(PLTOTEX) --out=$@ --section 'library(ssl)'
+crypto.tex:	crypto.pl
+		$(PLTOTEX) --out=$@ --section 'library(crypto)'
 saml.tex:	saml.pl
 		$(PLTOTEX) --out=$@ --subsection 'library(saml)'
 xmldsig.tex:	xmldsig.pl
@@ -111,7 +113,7 @@ check::
 ################################################################
 
 clean:
-		rm -f $(SSLOBJ) *~ *.o *% a.out core config.log ssl.tex
+		rm -f $(SSLOBJ) *~ *.o *% a.out core config.log ssl.tex crypto.tex
 		$(RUNTEX) --clean ssl
 
 distclean:	clean

--- a/Makefile.in
+++ b/Makefile.in
@@ -22,11 +22,14 @@ LIBPL=		@PLTARGETS@
 TARGETS=	@TARGETS@
 EXAMPLES=	client.pl server.pl https.pl
 
-SSLOBJ=		ssl4pl.o ssllib.o ../clib/nonblockio.o ../clib/error.o
+SSLOBJ=		crypto4pl.o ssl4pl.o ssllib.o ../clib/nonblockio.o ../clib/error.o
 
 all:		$(TARGETS)
 
 ssl4pl.@SO@:	$(SSLOBJ)
+		$(LD) $(LDSOFLAGS) -o $@ $(SSLOBJ) $(LIBS) $(LIBPLSO)
+
+crypto4pl.@SO@:	$(SSLOBJ)
 		$(LD) $(LDSOFLAGS) -o $@ $(SSLOBJ) $(LIBS) $(LIBPLSO)
 
 install:	$(TARGETS) $(LIBPL)

--- a/configure.in
+++ b/configure.in
@@ -73,8 +73,8 @@ if test -z "$SSLPREFIX"; then
 fi
 
 if test "$SSL_ok" = yes; then
-  TARGETS="ssl4pl.$SO"
-  PLTARGETS="ssl.pl saml.pl xmldsig.pl xmlenc.pl"
+  TARGETS="ssl4pl.$SO crypto4pl.$SO"
+  PLTARGETS="crypto.pl ssl.pl saml.pl xmldsig.pl xmlenc.pl"
 else
   TARGETS=""
   PLTARGETS=""

--- a/crypto.pl
+++ b/crypto.pl
@@ -56,8 +56,8 @@
 /** <module> Cryptography and authentication library
 
 This library provides bindings to functionality of OpenSSL that is
-related to cryptography and authentication.
-
+related to cryptography and authentication, not necessarily involving
+connections, sockets or streams.
 
 @author Matt Lilley
 @author [Markus Triska](https://www.metalevel.at)

--- a/crypto.pl
+++ b/crypto.pl
@@ -1,0 +1,217 @@
+/*  Part of SWI-Prolog
+
+    Author:        Matt Lilley and Markus Triska
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2004-2016, SWI-Prolog Foundation
+                              VU University Amsterdam
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(crypto,
+          [ evp_decrypt/6,              % +CipherText, +Algorithm, +Key, +IV, -PlainText, +Options
+            evp_encrypt/6,              % +PlainText, +Algorithm, +Key, +IV, -CipherText, +Options
+            rsa_private_decrypt/3,      % +Key, +Ciphertext, -Plaintext
+            rsa_private_encrypt/3,      % +Key, +Plaintext, -Ciphertext
+            rsa_public_decrypt/3,       % +Key, +Ciphertext, -Plaintext
+            rsa_public_encrypt/3,       % +Key, +Plaintext, -Ciphertext
+            rsa_private_decrypt/4,      % +Key, +Ciphertext, -Plaintext, +Enc
+            rsa_private_encrypt/4,      % +Key, +Plaintext, -Ciphertext, +Enc
+            rsa_public_decrypt/4,       % +Key, +Ciphertext, -Plaintext, +Enc
+            rsa_public_encrypt/4,       % +Key, +Plaintext, -Ciphertext, +Enc
+            rsa_sign/4,			% +Key, +Data, -Signature, +Options
+            rsa_verify/4		% +Key, +Data, -Signature, +Options
+	  ]).
+:- use_module(library(error)).
+:- use_module(library(option)).
+:- use_module(library(debug)).
+
+:- use_foreign_library(foreign(crypto4pl)).
+
+
+/** <module> Cryptography and authentication library
+
+This library provides bindings to functionality of OpenSSL that is
+related to cryptography and authentication.
+
+
+@author Matt Lilley
+@author [Markus Triska](https://www.metalevel.at)
+*/
+
+%%	rsa_private_decrypt(+PrivateKey, +CipherText, -PlainText) is det.
+%%      rsa_private_encrypt(+PrivateKey, +PlainText, -CipherText) is det.
+%%      rsa_public_decrypt(+PublicKey, +CipherText, -PlainText) is det.
+%%      rsa_public_encrypt(+PublicKey, +PlainText, -CipherText) is det.
+%%	rsa_private_decrypt(+PrivateKey, +CipherText, -PlainText, +Options) is det.
+%%      rsa_private_encrypt(+PrivateKey, +PlainText, -CipherText, +Options) is det.
+%%      rsa_public_decrypt(+PublicKey, +CipherText, -PlainText, +Options) is det.
+%%      rsa_public_encrypt(+PublicKey, +PlainText, -CipherText, +Options) is det.
+%
+%	RSA Public key encryption and   decryption  primitives. A string
+%	can be safely communicated by first   encrypting it and have the
+%	peer decrypt it with the matching  key and predicate. The length
+%	of the string is limited by  the   key  length.
+%
+%       Options:
+%
+%	  - encoding(+Encoding)
+%	  Encoding to use for Data.  Default is `utf8`.  Alternatives
+%	  are `utf8` and `octet`.
+%
+%	  - padding(+PaddingScheme)
+%	  Padding scheme to use.  Default is `pkcs1`.  Alternatives
+%	  are `pkcs1_oaep`, `sslv23` and `none`. Note that `none` should
+%         only be used if you implement cryptographically sound padding
+%         modes in your application code as encrypting unpadded data with
+%         RSA is insecure
+%
+%	@see load_private_key/3, load_public_key/2 can be use to load
+%	keys from a file.  The predicate load_certificate/2 can be used
+%	to obtain the public key from a certificate.
+%
+%	@error ssl_error(Code, LibName, FuncName, Reason)   is raised if
+%	there is an error, e.g., if the text is too long for the key.
+
+rsa_private_decrypt(PrivateKey, CipherText, PlainText) :-
+	rsa_private_decrypt(PrivateKey, CipherText, PlainText, [encoding(utf8)]).
+
+rsa_private_encrypt(PrivateKey, PlainText, CipherText) :-
+	rsa_private_encrypt(PrivateKey, PlainText, CipherText, [encoding(utf8)]).
+
+rsa_public_decrypt(PublicKey, CipherText, PlainText) :-
+	rsa_public_decrypt(PublicKey, CipherText, PlainText, [encoding(utf8)]).
+
+rsa_public_encrypt(PublicKey, PlainText, CipherText) :-
+	rsa_public_encrypt(PublicKey, PlainText, CipherText, [encoding(utf8)]).
+
+%%	rsa_sign(+Key, +Data, -Signature, +Options) is det.
+%
+%	Create an RSA signature for Data.  Options:
+%
+%	  - type(+Type)
+%	  SHA algorithm used to compute the digest.  Values are the
+%	  same as for sha_hash/3: `sha1` (default), `sha224`, `sha256`,
+%	  `sha384` or `sha512`
+%
+%	  - encoding(+Encoding)
+%	  Encoding to use for Data.  Default is `octet`.  Alternatives
+%	  are `utf8` and `text`.
+%
+%	This predicate is used  to   compute  a  _sha1WithRSAEncryption_
+%	signature as follows:
+%
+%	  ```
+%	  sha1_with_rsa(PemKeyFile, KeyPassword, Data, Signature) :-
+%	      DigestAlgorithm = sha1,
+%	      read_key(PemKeyFile, KeyPassword, PrivateKey),
+%	      sha_hash(Data, Digest, [algorithm(DigestAlgorithm)]),
+%	      rsa_sign(Key, Digest, Signature, [type(DigestAlgorithm)]).
+%
+%	  read_key(PemKeyFile, KeyPassword, PrivateKey) :-
+%	      setup_call_cleanup(
+%	          open(File, read, In, [type(binary)]),
+%	          load_private_key(In, Password, Key),
+%	          close(In).
+%	  ```
+
+rsa_sign(Key, Data, Signature, Options) :-
+	option(type(Type), Options, sha1),
+	option(encoding(Enc), Options, octet),
+	rsa_sign(Key, Type, Enc, Data, Signature).
+
+
+%%	rsa_verify(+Key, +Data, -Signature, +Options) is det.
+%
+%	Verifies an RSA signature for Data.  Options:
+%
+%	  - type(+Type)
+%	  SHA algorithm used to compute the digest.  Values are the
+%	  same as for sha_hash/3: `sha1` (default), `sha224`, `sha256`,
+%	  `sha384` or `sha512`
+%
+%	  - encoding(+Encoding)
+%	  Encoding to use for Data.  Default is `octet`.  Alternatives
+%	  are `utf8` and `text`.
+
+rsa_verify(Key, Data, Signature, Options) :-
+	option(type(Type), Options, sha1),
+	option(encoding(Enc), Options, octet),
+        rsa_verify(Key, Type, Enc, Data, Signature).
+
+%%	evp_decrypt(+CipherText,
+%%                  +Algorithm,
+%%                  +Key,
+%%                  +IV,
+%%                  -PlainText,
+%%                  +Options).
+%       Decrypt the given CipherText, using the symmetric algorithm Algorithm, key Key,
+%       and iv IV, to give PlainText. CipherText, Key and IV should all be strings, and
+%       PlainText is created as a string as well. Algorithm should be an algorithm which
+%       your copy of OpenSSL knows about. Examples are:
+%           * aes-128-cbc
+%           * aes-256-cbc
+%           * des3
+%       If the IV is not needed for your decryption algorithm (such as aes-128-ecb) then
+%       any string can be provided as it will be ignored by the underlying implementation
+%
+%       Options:
+%
+%	  - encoding(+Encoding)
+%	  Encoding to use for Data.  Default is `utf8`.  Alternatives
+%	  are `utf8` and `octet`.
+%
+%	  - padding(+PaddingScheme)
+%	  Padding scheme to use.  Default is `block`.  You can disable padding by supplying
+%         `none` here.
+%
+%       Example of aes-128-cbc encryption:
+%       ?- evp_encrypt("this is some input", 'aes-128-cbc', "sixteenbyteofkey",
+%                      "sixteenbytesofiv", CipherText, []),
+%          evp_decrypt(CipherText, 'aes-128-cbc', "sixteenbyteofkey", "sixteenbytesofiv",
+%                      RecoveredText, []).
+%       CipherText = <binary string>
+%       RecoveredText = "this is some input".
+
+%%	evp_encrypt(+PlainText,
+%%                  +Algorithm,
+%%                  +Key,
+%%                  +IV,
+%%                  -CipherTExt,
+%%                  +Options).
+%       Encrypt the given PlainText, using the symmetric algorithm Algorithm, key Key,
+%       and iv IV, to give CipherText. See evp_decrypt/6.
+
+		 /*******************************
+		 *	     MESSAGES		*
+		 *******************************/
+
+:- multifile
+	prolog:error_message//1.
+
+prolog:error_message(ssl_error(ID, _Library, Function, Reason)) -->
+	[ 'SSL(~w) ~w: ~w'-[ID, Function, Reason] ].

--- a/crypto.pl
+++ b/crypto.pl
@@ -43,9 +43,10 @@
             rsa_private_encrypt/4,      % +Key, +Plaintext, -Ciphertext, +Enc
             rsa_public_decrypt/4,       % +Key, +Ciphertext, -Plaintext, +Enc
             rsa_public_encrypt/4,       % +Key, +Plaintext, -Ciphertext, +Enc
-            rsa_sign/4,			% +Key, +Data, -Signature, +Options
-            rsa_verify/4		% +Key, +Data, -Signature, +Options
-	  ]).
+            rsa_sign/4,                 % +Key, +Data, -Signature, +Options
+            rsa_verify/4,               % +Key, +Data, -Signature, +Options
+            md5_hash/3                  % +Data, -Hash, +Options
+          ]).
 :- use_module(library(error)).
 :- use_module(library(option)).
 :- use_module(library(debug)).
@@ -205,6 +206,27 @@ rsa_verify(Key, Data, Signature, Options) :-
 %%                  +Options).
 %       Encrypt the given PlainText, using the symmetric algorithm Algorithm, key Key,
 %       and iv IV, to give CipherText. See evp_decrypt/6.
+
+%%	md5_hash(+Data, -Hash, +Options) is det.
+%
+%	Hash is the MD5 hash of Data.   The  conversion is controlled by
+%	Options:
+%
+%	  * encoding(+Encoding)
+%	  If Data is a sequence of character _codes_, this must be
+%	  translated into a sequence of _bytes_, because that is what
+%	  the hashing requires.  The default encoding is =utf8=.  The
+%	  other meaningful value is =octet=, claiming that Data contains
+%	  raw bytes.
+%
+%	@arg Data is either an atom, string, code-list or char-list.
+%	@arg Hash is an atom holding 32 characters, representing the
+%	hash in hexadecimal notation
+
+:- multifile sandbox:safe_primitive/1.
+
+sandbox:safe_primitive(crypto:md5_hash(_,_,_)).
+
 
 		 /*******************************
 		 *	     MESSAGES		*

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -1,0 +1,694 @@
+/*  Part of SWI-Prolog
+
+    Author:        Matt Lilley and Markus Triska
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2004-2016, SWI-Prolog Foundation
+                              VU University Amsterdam
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <config.h>
+#include <SWI-Stream.h>
+#include <SWI-Prolog.h>
+#include <assert.h>
+#include <string.h>
+#include "ssllib.h"
+
+#ifdef _REENTRANT
+#include <pthread.h>
+#endif
+
+static atom_t ATOM_sslv23;
+static atom_t ATOM_minus;			/* "-" */
+static atom_t ATOM_text;
+static atom_t ATOM_octet;
+static atom_t ATOM_utf8;
+
+static atom_t ATOM_sha1;
+static atom_t ATOM_sha224;
+static atom_t ATOM_sha256;
+static atom_t ATOM_sha384;
+static atom_t ATOM_sha512;
+
+static atom_t ATOM_pkcs;
+static atom_t ATOM_pkcs_oaep;
+static atom_t ATOM_none;
+static atom_t ATOM_block;
+static atom_t ATOM_encoding;
+static atom_t ATOM_padding;
+
+static functor_t FUNCTOR_public_key1;
+static functor_t FUNCTOR_private_key1;
+
+typedef enum
+{ RSA_MODE, EVP_MODE
+} crypt_mode_t;
+
+
+static int
+get_bn_arg(int a, term_t t, BIGNUM **bn)
+{ term_t arg;
+  char *hex;
+
+  if ( (arg=PL_new_term_ref()) &&
+       PL_get_arg(a, t, arg) &&
+       PL_get_chars(arg, &hex,
+		    CVT_ATOM|CVT_STRING|REP_ISO_LATIN_1|CVT_EXCEPTION) )
+  { if ( strcmp(hex, "-") == 0 )
+      *bn = NULL;
+    else
+      BN_hex2bn(bn, hex);
+
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+ 
+static int
+recover_rsa(term_t t, RSA** rsap)
+{ RSA *rsa = RSA_new();
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+  if ( get_bn_arg(1, t, &rsa->n) &&
+       get_bn_arg(2, t, &rsa->e) &&
+       get_bn_arg(3, t, &rsa->d) &&
+       get_bn_arg(4, t, &rsa->p) &&
+       get_bn_arg(5, t, &rsa->q) &&
+       get_bn_arg(6, t, &rsa->dmp1) &&
+       get_bn_arg(7, t, &rsa->dmq1) &&
+       get_bn_arg(8, t, &rsa->iqmp)
+     )
+  {
+#else
+  BIGNUM *n = NULL, *e = NULL, *d = NULL, *p = NULL,
+    *q = NULL, *dmp1 = NULL, *dmq1 = NULL, *iqmp = NULL;
+
+  if ( get_bn_arg(1, t, &n) &&
+       get_bn_arg(2, t, &e) &&
+       get_bn_arg(3, t, &d) &&
+       get_bn_arg(4, t, &p) &&
+       get_bn_arg(5, t, &q) &&
+       get_bn_arg(6, t, &dmp1) &&
+       get_bn_arg(7, t, &dmq1) &&
+       get_bn_arg(8, t, &iqmp) )
+  {
+    if ( !RSA_set0_key(rsa, n, e, d) ||
+         ( (p || q) && !RSA_set0_factors(rsa, p, q) ) ||
+         ( (dmp1 || dmq1 || iqmp) &&
+           !RSA_set0_crt_params(rsa, dmp1, dmq1, iqmp)) )
+    { RSA_free(rsa);
+      return FALSE;
+    }
+#endif
+    *rsap = rsa;
+    return TRUE;
+  }
+
+  RSA_free(rsa);
+  return FALSE;
+}
+
+
+static int
+recover_private_key(term_t t, RSA** rsap)
+{ if ( PL_is_functor(t, FUNCTOR_private_key1) )
+  { term_t arg;
+
+    if ( (arg = PL_new_term_ref()) &&
+	 PL_get_arg(1, t, arg) )
+      return recover_rsa(arg, rsap);
+
+    return FALSE;
+  }
+
+  return PL_type_error("private_key", t);
+}
+
+
+static int
+recover_public_key(term_t t, RSA** rsap)
+{ if ( PL_is_functor(t, FUNCTOR_public_key1) )
+  { term_t arg;
+
+    if ( (arg = PL_new_term_ref()) &&
+	 PL_get_arg(1, t, arg) )
+      return recover_rsa(arg, rsap);
+
+    return FALSE;
+  }
+
+  return PL_type_error("public_key", t);
+}
+
+
+		 /*******************************
+		 *       RSA ENCRYPT/DECRYPT	*
+		 *******************************/
+
+static int
+get_text_representation(term_t t, int *rep)
+{ atom_t a;
+
+  if ( PL_get_atom_ex(t, &a) )
+  { if      ( a == ATOM_octet ) *rep = REP_ISO_LATIN_1;
+    else if ( a == ATOM_utf8  ) *rep = REP_UTF8;
+    else if ( a == ATOM_text  ) *rep = REP_MB;
+    else return PL_domain_error("encoding", t);
+
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+static int
+get_padding(term_t t, crypt_mode_t mode, int *padding)
+{ atom_t a;
+
+  if ( PL_get_atom_ex(t, &a) )
+  { if      ( a == ATOM_pkcs && mode == RSA_MODE )       *padding = RSA_PKCS1_PADDING;
+    else if ( a == ATOM_pkcs_oaep && mode == RSA_MODE  ) *padding = RSA_PKCS1_OAEP_PADDING;
+    else if ( a == ATOM_none && mode == RSA_MODE  )      *padding = RSA_NO_PADDING;
+    else if ( a == ATOM_sslv23  && mode == RSA_MODE )    *padding = RSA_SSLV23_PADDING;
+    else if ( a == ATOM_none  && mode == EVP_MODE )      *padding = 0;
+    else if ( a == ATOM_block  && mode == EVP_MODE )     *padding = 1;
+    else return PL_domain_error("padding", t);
+
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+
+static int
+get_enc_text(term_t text, term_t enc, size_t *len, unsigned char **data)
+{ int flags;
+
+  if ( get_text_representation(enc, &flags) )
+  { flags |= CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION;
+    return PL_get_nchars(text, len, (char**)data, flags);
+  }
+
+  return FALSE;
+}
+
+
+static int
+parse_options(term_t options_t, crypt_mode_t mode, int* rep, int* padding)
+{ if (PL_is_atom(options_t)) /* Is really an encoding */
+  { if (rep == NULL)
+      return TRUE;
+    else if ( !get_text_representation(options_t, rep) )
+      return FALSE;
+  } else
+  { term_t tail = PL_copy_term_ref(options_t);
+    term_t head = PL_new_term_ref();
+
+    while( PL_get_list_ex(tail, head, tail) )
+    { atom_t name;
+      size_t arity;
+      term_t arg = PL_new_term_ref();
+
+      if ( !PL_get_name_arity(head, &name, &arity) ||
+           arity != 1 ||
+           !PL_get_arg(1, head, arg) )
+        return PL_type_error("option", head);
+
+      if ( name == ATOM_encoding )
+      { if ( !get_text_representation(arg, rep) )
+          return FALSE;
+      } else if ( name == ATOM_padding && padding != NULL)
+      { if ( !get_padding(arg, mode, padding) )
+        return FALSE;
+      }
+    }
+    if ( !PL_get_nil_ex(tail) )
+      return FALSE;
+  }
+
+  return TRUE;
+}
+
+static foreign_t
+pl_rsa_private_decrypt(term_t private_t, term_t cipher_t,
+		       term_t plain_t, term_t options_t)
+{ size_t cipher_length;
+  unsigned char* cipher;
+  unsigned char* plain;
+  int outsize;
+  RSA* key;
+  int rep = REP_UTF8;
+  int padding = RSA_PKCS1_PADDING;
+  int retval;
+
+  if ( !parse_options(options_t, RSA_MODE, &rep, &padding))
+    return FALSE;
+
+  if( !PL_get_nchars(cipher_t, &cipher_length, (char**)&cipher,
+		     CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION) )
+    return FALSE;
+  if ( !recover_private_key(private_t, &key) )
+    return FALSE;
+
+  outsize = RSA_size(key);
+  ssl_deb(1, "Output size is going to be %d", outsize);
+  plain = PL_malloc(outsize);
+  ssl_deb(1, "Allocated %d bytes for plaintext", outsize);
+  if ((outsize = RSA_private_decrypt((int)cipher_length, cipher,
+				     plain, key, padding)) <= 0)
+  { ssl_deb(1, "Failure to decrypt!");
+    RSA_free(key);
+    PL_free(plain);
+    return raise_ssl_error(ERR_get_error());
+  }
+  ssl_deb(1, "decrypted bytes: %d", outsize);
+  ssl_deb(1, "Freeing RSA");
+  RSA_free(key);
+  ssl_deb(1, "Assembling plaintext");
+  retval = PL_unify_chars(plain_t, rep | PL_STRING, outsize, (char*)plain);
+  ssl_deb(1, "Freeing plaintext");
+  PL_free(plain);
+  ssl_deb(1, "Done");
+
+  return retval;
+}
+
+static foreign_t
+pl_rsa_public_decrypt(term_t public_t, term_t cipher_t,
+                      term_t plain_t, term_t options_t)
+{ size_t cipher_length;
+  unsigned char* cipher;
+  unsigned char* plain;
+  int outsize;
+  RSA* key;
+  int rep = REP_UTF8;
+  int padding = RSA_PKCS1_PADDING;
+  int retval;
+
+  if ( !parse_options(options_t, RSA_MODE, &rep, &padding))
+    return FALSE;
+  if ( !PL_get_nchars(cipher_t, &cipher_length, (char**)&cipher,
+		      CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION) )
+    return FALSE;
+  if ( !recover_public_key(public_t, &key) )
+    return FALSE;
+
+  outsize = RSA_size(key);
+  ssl_deb(1, "Output size is going to be %d", outsize);
+  plain = PL_malloc(outsize);
+  ssl_deb(1, "Allocated %d bytes for plaintext", outsize);
+  if ((outsize = RSA_public_decrypt((int)cipher_length, cipher,
+                                    plain, key, padding)) <= 0)
+  { ssl_deb(1, "Failure to decrypt!");
+    RSA_free(key);
+    PL_free(plain);
+    return raise_ssl_error(ERR_get_error());
+  }
+  ssl_deb(1, "decrypted bytes: %d", outsize);
+  ssl_deb(1, "Freeing RSA");
+  RSA_free(key);
+  ssl_deb(1, "Assembling plaintext");
+  retval = PL_unify_chars(plain_t, rep | PL_STRING, outsize, (char*)plain);
+  ssl_deb(1, "Freeing plaintext");
+  PL_free(plain);
+  ssl_deb(1, "Done");
+
+  return retval;
+}
+
+static foreign_t
+pl_rsa_public_encrypt(term_t public_t,
+                      term_t plain_t, term_t cipher_t, term_t options_t)
+{ size_t plain_length;
+  unsigned char* cipher;
+  unsigned char* plain;
+  int outsize;
+  RSA* key;
+  int rep = REP_UTF8;
+  int padding = RSA_PKCS1_PADDING;
+  int retval;
+
+  if ( !parse_options(options_t, RSA_MODE, &rep, &padding))
+    return FALSE;
+
+  ssl_deb(1, "Generating terms");
+  ssl_deb(1, "Collecting plaintext");
+  if ( !PL_get_nchars(plain_t, &plain_length, (char**)&plain,
+		      CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION | rep))
+    return FALSE;
+  if ( !recover_public_key(public_t, &key) )
+    return FALSE;
+
+  outsize = RSA_size(key);
+  ssl_deb(1, "Output size is going to be %d\n", outsize);
+  cipher = PL_malloc(outsize);
+  ssl_deb(1, "Allocated %d bytes for ciphertext\n", outsize);
+  if ( (outsize = RSA_public_encrypt((int)plain_length, plain,
+				     cipher, key, padding)) <= 0)
+  { ssl_deb(1, "Failure to encrypt!");
+    PL_free(cipher);
+    RSA_free(key);
+    return raise_ssl_error(ERR_get_error());
+  }
+  ssl_deb(1, "encrypted bytes: %d\n", outsize);
+  ssl_deb(1, "Freeing RSA");
+  RSA_free(key);
+  ssl_deb(1, "Assembling plaintext");
+  retval = PL_unify_chars(cipher_t, PL_STRING|REP_ISO_LATIN_1,
+			  outsize, (char*)cipher);
+  ssl_deb(1, "Freeing plaintext");
+  PL_free(cipher);
+  ssl_deb(1, "Done");
+
+  return retval;
+}
+
+
+static foreign_t
+pl_rsa_private_encrypt(term_t private_t,
+                       term_t plain_t, term_t cipher_t, term_t options_t)
+{ size_t plain_length;
+  unsigned char* cipher;
+  unsigned char* plain;
+  int outsize;
+  RSA* key;
+  int rep = REP_UTF8;
+  int padding = RSA_PKCS1_PADDING;
+  int retval;
+
+  if ( !parse_options(options_t, RSA_MODE, &rep, &padding))
+    return FALSE;
+
+  if ( !PL_get_nchars(plain_t, &plain_length, (char**)&plain,
+		      CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION | rep))
+    return FALSE;
+  if ( !recover_private_key(private_t, &key) )
+    return FALSE;
+
+  outsize = RSA_size(key);
+  ssl_deb(1, "Output size is going to be %d", outsize);
+  cipher = PL_malloc(outsize);
+  ssl_deb(1, "Allocated %d bytes for ciphertext", outsize);
+  if ((outsize = RSA_private_encrypt((int)plain_length, plain,
+                                     cipher, key, padding)) <= 0)
+  { ssl_deb(1, "Failure to encrypt!");
+    PL_free(cipher);
+    RSA_free(key);
+    return raise_ssl_error(ERR_get_error());
+  }
+  ssl_deb(1, "encrypted bytes: %d", outsize);
+  ssl_deb(1, "Freeing RSA");
+  RSA_free(key);
+  ssl_deb(1, "Assembling plaintext");
+  retval = PL_unify_chars(cipher_t, PL_STRING|REP_ISO_LATIN_1,
+			  outsize, (char*)cipher);
+  ssl_deb(1, "Freeing cipher");
+  PL_free(cipher);
+  ssl_deb(1, "Done");
+
+  return retval;
+}
+
+
+static int
+get_digest_type(term_t t, int *type)
+{ atom_t a;
+
+  if ( PL_get_atom_ex(t, &a) )
+  { if      ( a == ATOM_sha1   ) *type = NID_sha1;
+    else if ( a == ATOM_sha224 ) *type = NID_sha224;
+    else if ( a == ATOM_sha256 ) *type = NID_sha256;
+    else if ( a == ATOM_sha384 ) *type = NID_sha384;
+    else if ( a == ATOM_sha512 ) *type = NID_sha512;
+    else
+    { PL_domain_error("digest_type", t);
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+
+static foreign_t
+pl_rsa_sign(term_t Private, term_t Type, term_t Enc,
+	    term_t Data, term_t Signature)
+{ unsigned char *data;
+  size_t data_len;
+  RSA *key;
+  unsigned char *signature;
+  unsigned int signature_len;
+  int rc;
+  int type;
+
+  if ( !get_enc_text(Data, Enc, &data_len, &data) ||
+       !recover_private_key(Private, &key) ||
+       !get_digest_type(Type, &type) )
+    return FALSE;
+
+  signature_len = RSA_size(key);
+  signature = PL_malloc(signature_len);
+  rc = RSA_sign(type,
+		data, (unsigned int)data_len,
+		signature, &signature_len, key);
+  RSA_free(key);
+  if ( rc != 1 )
+  { PL_free(signature);
+    return raise_ssl_error(ERR_get_error());
+  }
+  rc = PL_unify_chars(Signature, PL_STRING|REP_ISO_LATIN_1,
+		      signature_len, (char*)signature);
+  PL_free(signature);
+
+  return rc;
+}
+
+static foreign_t
+pl_rsa_verify(term_t Public, term_t Type, term_t Enc,
+	    term_t Data, term_t Signature)
+{ unsigned char *data;
+  size_t data_len;
+  RSA *key;
+  unsigned char *signature;
+  size_t signature_len;
+  int rc;
+  int type;
+
+  if ( !get_enc_text(Data, Enc, &data_len, &data) ||
+       !recover_public_key(Public, &key) ||
+       !get_digest_type(Type, &type) ||
+       !PL_get_nchars(Signature, &signature_len, (char**)&signature, CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION) )
+    return FALSE;
+
+  rc = RSA_verify(type,
+                  data, (unsigned int)data_len,
+                  signature, (unsigned int)signature_len, key);
+  RSA_free(key);
+  if ( rc != 1 )
+  { return raise_ssl_error(ERR_get_error());
+  }
+  return 1;
+}
+
+
+
+#ifndef HAVE_EVP_CIPHER_CTX_RESET
+#define EVP_CIPHER_CTX_reset(C) EVP_CIPHER_CTX_init(C)
+#endif
+
+static foreign_t
+pl_evp_decrypt(term_t ciphertext_t, term_t algorithm_t,
+	       term_t key_t, term_t iv_t, term_t plaintext_t,
+	       term_t options_t)
+{ EVP_CIPHER_CTX* ctx = NULL;
+  const EVP_CIPHER *cipher;
+  char* key;
+  char* iv;
+  char* ciphertext;
+  size_t cipher_length;
+  int plain_length;
+  char* algorithm;
+  char* plaintext;
+  int cvt_flags = CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION;
+  int rep = REP_UTF8;
+  int padding = 1;
+
+  if ( !parse_options(options_t, EVP_MODE, &rep, &padding))
+    return FALSE;
+
+  if ( !PL_get_chars(key_t, &key, cvt_flags) ||
+       !PL_get_chars(iv_t, &iv, cvt_flags) ||
+       !PL_get_nchars(ciphertext_t, &cipher_length, &ciphertext, cvt_flags) ||
+       !PL_get_chars(algorithm_t, &algorithm, cvt_flags) )
+    return FALSE;
+
+  if ( (cipher = EVP_get_cipherbyname(algorithm)) == NULL )
+    return PL_domain_error("cipher", algorithm_t);
+  if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
+    return FALSE;
+
+  EVP_CIPHER_CTX_reset(ctx);
+  EVP_DecryptInit_ex(ctx, cipher, NULL,
+		     (const unsigned char*)key, (const unsigned char*)iv);
+  EVP_CIPHER_CTX_set_padding(ctx, padding);
+  plaintext = PL_malloc(cipher_length + EVP_CIPHER_block_size(cipher));
+  if ( EVP_DecryptUpdate(ctx, (unsigned char*)plaintext, &plain_length,
+			 (unsigned char*)ciphertext, cipher_length) == 1 )
+  { int last_chunk = plain_length;
+    int rc;
+    rc = EVP_DecryptFinal_ex(ctx, (unsigned char*)(plaintext + plain_length),
+                              &last_chunk);
+    EVP_CIPHER_CTX_free(ctx);
+    ERR_print_errors_fp(stderr);
+    rc &= PL_unify_chars(plaintext_t, rep | PL_STRING, plain_length + last_chunk,
+                         plaintext);
+    PL_free(plaintext);
+    return rc;
+  }
+
+  PL_free(plaintext);
+  EVP_CIPHER_CTX_free(ctx);
+
+  return FALSE;
+}
+
+static foreign_t
+pl_evp_encrypt(term_t plaintext_t, term_t algorithm_t,
+               term_t key_t, term_t iv_t, term_t ciphertext_t,
+	       term_t options_t)
+{ EVP_CIPHER_CTX* ctx = NULL;
+  const EVP_CIPHER *cipher;
+  char* key;
+  char* iv;
+  char* ciphertext;
+  int cipher_length;
+  char* algorithm;
+  char* plaintext;
+  size_t plain_length;
+  int cvt_flags = CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION;
+  int rep = REP_UTF8;
+
+  if ( !parse_options(options_t, EVP_MODE, &rep, NULL))
+    return FALSE;
+
+  if ( !PL_get_chars(key_t, &key, cvt_flags) ||
+       !PL_get_chars(iv_t, &iv, cvt_flags) ||
+       !PL_get_nchars(plaintext_t, &plain_length, &plaintext, cvt_flags | rep) ||
+       !PL_get_chars(algorithm_t, &algorithm, cvt_flags) )
+    return FALSE;
+
+  if ( (cipher = EVP_get_cipherbyname(algorithm)) == NULL )
+    return PL_domain_error("cipher", algorithm_t);
+  if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
+    return FALSE;
+
+  EVP_CIPHER_CTX_reset(ctx);
+  EVP_EncryptInit_ex(ctx, cipher, NULL,
+		     (const unsigned char*)key, (const unsigned char*)iv);
+
+  ciphertext = PL_malloc(plain_length + EVP_CIPHER_block_size(cipher));
+  if ( EVP_EncryptUpdate(ctx, (unsigned char*)ciphertext, &cipher_length,
+                         (unsigned char*)plaintext, plain_length) == 1 )
+  { int last_chunk;
+    int rc;
+
+    EVP_EncryptFinal_ex(ctx, (unsigned char*)(ciphertext + cipher_length),
+			&last_chunk);
+    EVP_CIPHER_CTX_free(ctx);
+    rc = PL_unify_chars(ciphertext_t,  PL_STRING|REP_ISO_LATIN_1,
+			cipher_length + last_chunk, ciphertext);
+    PL_free(ciphertext);
+    return rc;
+  }
+
+  PL_free(ciphertext);
+  EVP_CIPHER_CTX_free(ctx);
+
+  return FALSE;
+}
+
+		 /*******************************
+		 *	     INSTALL		*
+		 *******************************/
+
+
+install_t
+install_crypto4pl(void)
+{
+  ATOM_sslv23               = PL_new_atom("sslv23");
+  ATOM_minus                = PL_new_atom("-");
+  ATOM_text                 = PL_new_atom("text");
+  ATOM_octet                = PL_new_atom("octet");
+  ATOM_utf8                 = PL_new_atom("utf8");
+  ATOM_sha1                 = PL_new_atom("sha1");
+  ATOM_sha224               = PL_new_atom("sha224");
+  ATOM_sha256               = PL_new_atom("sha256");
+  ATOM_sha384               = PL_new_atom("sha384");
+  ATOM_sha512               = PL_new_atom("sha512");
+  ATOM_pkcs                 = PL_new_atom("pkcs");
+  ATOM_pkcs_oaep            = PL_new_atom("pkcs_oaep");
+  ATOM_none                 = PL_new_atom("none");
+  ATOM_block                = PL_new_atom("block");
+  ATOM_encoding             = PL_new_atom("encoding");
+  ATOM_padding              = PL_new_atom("padding");
+
+  FUNCTOR_public_key1       = PL_new_functor(PL_new_atom("public_key"), 1);
+  FUNCTOR_private_key1      = PL_new_functor(PL_new_atom("private_key"), 1);
+
+  PL_register_foreign("rsa_private_decrypt", 4, pl_rsa_private_decrypt, 0);
+  PL_register_foreign("rsa_private_encrypt", 4, pl_rsa_private_encrypt, 0);
+  PL_register_foreign("rsa_public_decrypt", 4, pl_rsa_public_decrypt, 0);
+  PL_register_foreign("rsa_public_encrypt", 4, pl_rsa_public_encrypt, 0);
+  PL_register_foreign("rsa_sign", 5, pl_rsa_sign, 0);
+  PL_register_foreign("rsa_verify", 5, pl_rsa_verify, 0);
+  PL_register_foreign("evp_decrypt",        6, pl_evp_decrypt, 0);
+  PL_register_foreign("evp_encrypt",        6, pl_evp_encrypt, 0);
+
+  /*
+   * Initialize ssllib
+   */
+  (void) ssl_lib_init();
+
+  PL_set_prolog_flag("ssl_library_version", PL_ATOM,
+#ifdef HAVE_OPENSSL_VERSION
+		     OpenSSL_version(OPENSSL_VERSION)
+#else
+		     SSLeay_version(SSLEAY_VERSION)
+#endif
+		     );
+}
+
+install_t
+uninstall_crypto4pl(void)
+{ ssl_lib_exit();
+}

--- a/ssl.doc
+++ b/ssl.doc
@@ -71,6 +71,8 @@ and tips for managing certificates and keys.
 
 \input{ssllib.tex}
 
+\input{crypto.tex}
+
 \section{XML cryptographic libraries}
 \label{sec:ssl-xml-libs}
 

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -360,29 +360,6 @@ unify_asn1_time(term_t term, const ASN1_TIME *time)
   return PL_unify_int64(term, result);
 }
 
-#if !defined(HAVE_OPENSSL_ZALLOC) && !defined(OPENSSL_zalloc)
-static void *
-OPENSSL_zalloc(size_t num)
-{ void *ret = OPENSSL_malloc(num);
-  if (ret != NULL)
-    memset(ret, 0, num);
-  return ret;
-}
-#endif
-
-#ifndef HAVE_EVP_MD_CTX_FREE
-void
-EVP_MD_CTX_free(EVP_MD_CTX *ctx)
-{ EVP_MD_CTX_cleanup(ctx);
-  OPENSSL_free(ctx);
-}
-
-EVP_MD_CTX *
-EVP_MD_CTX_new(void)
-{ return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
-}
-#endif
-
 static int
 unify_hash(term_t hash, const ASN1_OBJECT* algorithm,
 	   int (*i2d)(void*, unsigned char**), void * data)

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -76,29 +76,12 @@ static atom_t ATOM_tlsv1;
 static atom_t ATOM_tlsv1_1;
 static atom_t ATOM_tlsv1_2;
 static atom_t ATOM_minus;			/* "-" */
-static atom_t ATOM_text;
-static atom_t ATOM_octet;
-static atom_t ATOM_utf8;
-
-static atom_t ATOM_sha1;
-static atom_t ATOM_sha224;
-static atom_t ATOM_sha256;
-static atom_t ATOM_sha384;
-static atom_t ATOM_sha512;
-
-static atom_t ATOM_pkcs;
-static atom_t ATOM_pkcs_oaep;
-static atom_t ATOM_none;
-static atom_t ATOM_block;
-static atom_t ATOM_encoding;
-static atom_t ATOM_padding;
 
 static functor_t FUNCTOR_unsupported_hash_algorithm1;
 static functor_t FUNCTOR_system1;
        functor_t FUNCTOR_error2;	/* also used in ssllib.c */
        functor_t FUNCTOR_ssl_error4;	/* also used in ssllib.c */
 static functor_t FUNCTOR_permission_error3;
-static functor_t FUNCTOR_ip4;
 static functor_t FUNCTOR_version1;
 static functor_t FUNCTOR_notbefore1;
 static functor_t FUNCTOR_notafter1;
@@ -191,28 +174,6 @@ get_predicate_arg(int a, module_t m, term_t t, int arity, predicate_t *pred)
   return TRUE;
 }
 
-
-static int
-get_bn_arg(int a, term_t t, BIGNUM **bn)
-{ term_t arg;
-  char *hex;
-
-  if ( (arg=PL_new_term_ref()) &&
-       PL_get_arg(a, t, arg) &&
-       PL_get_chars(arg, &hex,
-		    CVT_ATOM|CVT_STRING|REP_ISO_LATIN_1|CVT_EXCEPTION) )
-  { if ( strcmp(hex, "-") == 0 )
-      *bn = NULL;
-    else
-      BN_hex2bn(bn, hex);
-
-    return TRUE;
-  }
-
-  return FALSE;
-}
-
-
 static int
 unify_bignum_arg(int a, term_t t, const BIGNUM *bn)
 { term_t arg;
@@ -234,83 +195,6 @@ unify_bignum_arg(int a, term_t t, const BIGNUM *bn)
   }
 
   return FALSE;
-}
-
-
-static int
-recover_rsa(term_t t, RSA** rsap)
-{ RSA *rsa = RSA_new();
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-  if ( get_bn_arg(1, t, &rsa->n) &&
-       get_bn_arg(2, t, &rsa->e) &&
-       get_bn_arg(3, t, &rsa->d) &&
-       get_bn_arg(4, t, &rsa->p) &&
-       get_bn_arg(5, t, &rsa->q) &&
-       get_bn_arg(6, t, &rsa->dmp1) &&
-       get_bn_arg(7, t, &rsa->dmq1) &&
-       get_bn_arg(8, t, &rsa->iqmp)
-     )
-  {
-#else
-  BIGNUM *n = NULL, *e = NULL, *d = NULL, *p = NULL,
-    *q = NULL, *dmp1 = NULL, *dmq1 = NULL, *iqmp = NULL;
-
-  if ( get_bn_arg(1, t, &n) &&
-       get_bn_arg(2, t, &e) &&
-       get_bn_arg(3, t, &d) &&
-       get_bn_arg(4, t, &p) &&
-       get_bn_arg(5, t, &q) &&
-       get_bn_arg(6, t, &dmp1) &&
-       get_bn_arg(7, t, &dmq1) &&
-       get_bn_arg(8, t, &iqmp) )
-  {
-    if ( !RSA_set0_key(rsa, n, e, d) ||
-         ( (p || q) && !RSA_set0_factors(rsa, p, q) ) ||
-         ( (dmp1 || dmq1 || iqmp) &&
-           !RSA_set0_crt_params(rsa, dmp1, dmq1, iqmp)) )
-    { RSA_free(rsa);
-      return FALSE;
-    }
-#endif
-    *rsap = rsa;
-    return TRUE;
-  }
-
-  RSA_free(rsa);
-  return FALSE;
-}
-
-
-static int
-recover_private_key(term_t t, RSA** rsap)
-{ if ( PL_is_functor(t, FUNCTOR_private_key1) )
-  { term_t arg;
-
-    if ( (arg = PL_new_term_ref()) &&
-	 PL_get_arg(1, t, arg) )
-      return recover_rsa(arg, rsap);
-
-    return FALSE;
-  }
-
-  return PL_type_error("private_key", t);
-}
-
-
-static int
-recover_public_key(term_t t, RSA** rsap)
-{ if ( PL_is_functor(t, FUNCTOR_public_key1) )
-  { term_t arg;
-
-    if ( (arg = PL_new_term_ref()) &&
-	 PL_get_arg(1, t, arg) )
-      return recover_rsa(arg, rsap);
-
-    return FALSE;
-  }
-
-  return PL_type_error("public_key", t);
 }
 
 
@@ -347,7 +231,6 @@ unify_rsa(term_t item, RSA* rsa)
 	 );
 #endif
 }
-
 
 static int
 unify_bytes_hex(term_t t, size_t len, const unsigned char *data)
@@ -690,7 +573,6 @@ unify_crl(term_t term, X509_CRL* crl)
   BIO_free(mem);
   return result && PL_unify_nil(list);
 }
-
 
 static int
 unify_key(EVP_PKEY* key, functor_t type, term_t item)
@@ -1712,358 +1594,6 @@ pl_ssl_negotiate(term_t config,
 }
 
 
-		 /*******************************
-		 *       RSA ENCRYPT/DECRYPT	*
-		 *******************************/
-
-static int
-get_text_representation(term_t t, int *rep)
-{ atom_t a;
-
-  if ( PL_get_atom_ex(t, &a) )
-  { if      ( a == ATOM_octet ) *rep = REP_ISO_LATIN_1;
-    else if ( a == ATOM_utf8  ) *rep = REP_UTF8;
-    else if ( a == ATOM_text  ) *rep = REP_MB;
-    else return PL_domain_error("encoding", t);
-
-    return TRUE;
-  }
-
-  return FALSE;
-}
-
-static int
-get_padding(term_t t, crypt_mode_t mode, int *padding)
-{ atom_t a;
-
-  if ( PL_get_atom_ex(t, &a) )
-  { if      ( a == ATOM_pkcs && mode == RSA_MODE )       *padding = RSA_PKCS1_PADDING;
-    else if ( a == ATOM_pkcs_oaep && mode == RSA_MODE  ) *padding = RSA_PKCS1_OAEP_PADDING;
-    else if ( a == ATOM_none && mode == RSA_MODE  )      *padding = RSA_NO_PADDING;
-    else if ( a == ATOM_sslv23  && mode == RSA_MODE )    *padding = RSA_SSLV23_PADDING;
-    else if ( a == ATOM_none  && mode == EVP_MODE )      *padding = 0;
-    else if ( a == ATOM_block  && mode == EVP_MODE )     *padding = 1;
-    else return PL_domain_error("padding", t);
-
-    return TRUE;
-  }
-
-  return FALSE;
-}
-
-
-static int
-get_enc_text(term_t text, term_t enc, size_t *len, unsigned char **data)
-{ int flags;
-
-  if ( get_text_representation(enc, &flags) )
-  { flags |= CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION;
-    return PL_get_nchars(text, len, (char**)data, flags);
-  }
-
-  return FALSE;
-}
-
-
-static int
-parse_options(term_t options_t, crypt_mode_t mode, int* rep, int* padding)
-{ if (PL_is_atom(options_t)) /* Is really an encoding */
-  { if (rep == NULL)
-      return TRUE;
-    else if ( !get_text_representation(options_t, rep) )
-      return FALSE;
-  } else
-  { term_t tail = PL_copy_term_ref(options_t);
-    term_t head = PL_new_term_ref();
-
-    while( PL_get_list_ex(tail, head, tail) )
-    { atom_t name;
-      size_t arity;
-      term_t arg = PL_new_term_ref();
-
-      if ( !PL_get_name_arity(head, &name, &arity) ||
-           arity != 1 ||
-           !PL_get_arg(1, head, arg) )
-        return PL_type_error("option", head);
-
-      if ( name == ATOM_encoding )
-      { if ( !get_text_representation(arg, rep) )
-          return FALSE;
-      } else if ( name == ATOM_padding && padding != NULL)
-      { if ( !get_padding(arg, mode, padding) )
-        return FALSE;
-      }
-    }
-    if ( !PL_get_nil_ex(tail) )
-      return FALSE;
-  }
-
-  return TRUE;
-}
-
-static foreign_t
-pl_rsa_private_decrypt(term_t private_t, term_t cipher_t,
-		       term_t plain_t, term_t options_t)
-{ size_t cipher_length;
-  unsigned char* cipher;
-  unsigned char* plain;
-  int outsize;
-  RSA* key;
-  int rep = REP_UTF8;
-  int padding = RSA_PKCS1_PADDING;
-  int retval;
-
-  if ( !parse_options(options_t, RSA_MODE, &rep, &padding))
-    return FALSE;
-
-  if( !PL_get_nchars(cipher_t, &cipher_length, (char**)&cipher,
-		     CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION) )
-    return FALSE;
-  if ( !recover_private_key(private_t, &key) )
-    return FALSE;
-
-  outsize = RSA_size(key);
-  ssl_deb(1, "Output size is going to be %d", outsize);
-  plain = PL_malloc(outsize);
-  ssl_deb(1, "Allocated %d bytes for plaintext", outsize);
-  if ((outsize = RSA_private_decrypt((int)cipher_length, cipher,
-				     plain, key, padding)) <= 0)
-  { ssl_deb(1, "Failure to decrypt!");
-    RSA_free(key);
-    PL_free(plain);
-    return raise_ssl_error(ERR_get_error());
-  }
-  ssl_deb(1, "decrypted bytes: %d", outsize);
-  ssl_deb(1, "Freeing RSA");
-  RSA_free(key);
-  ssl_deb(1, "Assembling plaintext");
-  retval = PL_unify_chars(plain_t, rep | PL_STRING, outsize, (char*)plain);
-  ssl_deb(1, "Freeing plaintext");
-  PL_free(plain);
-  ssl_deb(1, "Done");
-
-  return retval;
-}
-
-static foreign_t
-pl_rsa_public_decrypt(term_t public_t, term_t cipher_t,
-                      term_t plain_t, term_t options_t)
-{ size_t cipher_length;
-  unsigned char* cipher;
-  unsigned char* plain;
-  int outsize;
-  RSA* key;
-  int rep = REP_UTF8;
-  int padding = RSA_PKCS1_PADDING;
-  int retval;
-
-  if ( !parse_options(options_t, RSA_MODE, &rep, &padding))
-    return FALSE;
-  if ( !PL_get_nchars(cipher_t, &cipher_length, (char**)&cipher,
-		      CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION) )
-    return FALSE;
-  if ( !recover_public_key(public_t, &key) )
-    return FALSE;
-
-  outsize = RSA_size(key);
-  ssl_deb(1, "Output size is going to be %d", outsize);
-  plain = PL_malloc(outsize);
-  ssl_deb(1, "Allocated %d bytes for plaintext", outsize);
-  if ((outsize = RSA_public_decrypt((int)cipher_length, cipher,
-                                    plain, key, padding)) <= 0)
-  { ssl_deb(1, "Failure to decrypt!");
-    RSA_free(key);
-    PL_free(plain);
-    return raise_ssl_error(ERR_get_error());
-  }
-  ssl_deb(1, "decrypted bytes: %d", outsize);
-  ssl_deb(1, "Freeing RSA");
-  RSA_free(key);
-  ssl_deb(1, "Assembling plaintext");
-  retval = PL_unify_chars(plain_t, rep | PL_STRING, outsize, (char*)plain);
-  ssl_deb(1, "Freeing plaintext");
-  PL_free(plain);
-  ssl_deb(1, "Done");
-
-  return retval;
-}
-
-static foreign_t
-pl_rsa_public_encrypt(term_t public_t,
-                      term_t plain_t, term_t cipher_t, term_t options_t)
-{ size_t plain_length;
-  unsigned char* cipher;
-  unsigned char* plain;
-  int outsize;
-  RSA* key;
-  int rep = REP_UTF8;
-  int padding = RSA_PKCS1_PADDING;
-  int retval;
-
-  if ( !parse_options(options_t, RSA_MODE, &rep, &padding))
-    return FALSE;
-
-  ssl_deb(1, "Generating terms");
-  ssl_deb(1, "Collecting plaintext");
-  if ( !PL_get_nchars(plain_t, &plain_length, (char**)&plain,
-		      CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION | rep))
-    return FALSE;
-  if ( !recover_public_key(public_t, &key) )
-    return FALSE;
-
-  outsize = RSA_size(key);
-  ssl_deb(1, "Output size is going to be %d\n", outsize);
-  cipher = PL_malloc(outsize);
-  ssl_deb(1, "Allocated %d bytes for ciphertext\n", outsize);
-  if ( (outsize = RSA_public_encrypt((int)plain_length, plain,
-				     cipher, key, padding)) <= 0)
-  { ssl_deb(1, "Failure to encrypt!");
-    PL_free(cipher);
-    RSA_free(key);
-    return raise_ssl_error(ERR_get_error());
-  }
-  ssl_deb(1, "encrypted bytes: %d\n", outsize);
-  ssl_deb(1, "Freeing RSA");
-  RSA_free(key);
-  ssl_deb(1, "Assembling plaintext");
-  retval = PL_unify_chars(cipher_t, PL_STRING|REP_ISO_LATIN_1,
-			  outsize, (char*)cipher);
-  ssl_deb(1, "Freeing plaintext");
-  PL_free(cipher);
-  ssl_deb(1, "Done");
-
-  return retval;
-}
-
-
-static foreign_t
-pl_rsa_private_encrypt(term_t private_t,
-                       term_t plain_t, term_t cipher_t, term_t options_t)
-{ size_t plain_length;
-  unsigned char* cipher;
-  unsigned char* plain;
-  int outsize;
-  RSA* key;
-  int rep = REP_UTF8;
-  int padding = RSA_PKCS1_PADDING;
-  int retval;
-
-  if ( !parse_options(options_t, RSA_MODE, &rep, &padding))
-    return FALSE;
-
-  if ( !PL_get_nchars(plain_t, &plain_length, (char**)&plain,
-		      CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION | rep))
-    return FALSE;
-  if ( !recover_private_key(private_t, &key) )
-    return FALSE;
-
-  outsize = RSA_size(key);
-  ssl_deb(1, "Output size is going to be %d", outsize);
-  cipher = PL_malloc(outsize);
-  ssl_deb(1, "Allocated %d bytes for ciphertext", outsize);
-  if ((outsize = RSA_private_encrypt((int)plain_length, plain,
-                                     cipher, key, padding)) <= 0)
-  { ssl_deb(1, "Failure to encrypt!");
-    PL_free(cipher);
-    RSA_free(key);
-    return raise_ssl_error(ERR_get_error());
-  }
-  ssl_deb(1, "encrypted bytes: %d", outsize);
-  ssl_deb(1, "Freeing RSA");
-  RSA_free(key);
-  ssl_deb(1, "Assembling plaintext");
-  retval = PL_unify_chars(cipher_t, PL_STRING|REP_ISO_LATIN_1,
-			  outsize, (char*)cipher);
-  ssl_deb(1, "Freeing cipher");
-  PL_free(cipher);
-  ssl_deb(1, "Done");
-
-  return retval;
-}
-
-
-static int
-get_digest_type(term_t t, int *type)
-{ atom_t a;
-
-  if ( PL_get_atom_ex(t, &a) )
-  { if      ( a == ATOM_sha1   ) *type = NID_sha1;
-    else if ( a == ATOM_sha224 ) *type = NID_sha224;
-    else if ( a == ATOM_sha256 ) *type = NID_sha256;
-    else if ( a == ATOM_sha384 ) *type = NID_sha384;
-    else if ( a == ATOM_sha512 ) *type = NID_sha512;
-    else
-    { PL_domain_error("digest_type", t);
-      return FALSE;
-    }
-
-    return TRUE;
-  }
-
-  return FALSE;
-}
-
-
-static foreign_t
-pl_rsa_sign(term_t Private, term_t Type, term_t Enc,
-	    term_t Data, term_t Signature)
-{ unsigned char *data;
-  size_t data_len;
-  RSA *key;
-  unsigned char *signature;
-  unsigned int signature_len;
-  int rc;
-  int type;
-
-  if ( !get_enc_text(Data, Enc, &data_len, &data) ||
-       !recover_private_key(Private, &key) ||
-       !get_digest_type(Type, &type) )
-    return FALSE;
-
-  signature_len = RSA_size(key);
-  signature = PL_malloc(signature_len);
-  rc = RSA_sign(type,
-		data, (unsigned int)data_len,
-		signature, &signature_len, key);
-  RSA_free(key);
-  if ( rc != 1 )
-  { PL_free(signature);
-    return raise_ssl_error(ERR_get_error());
-  }
-  rc = PL_unify_chars(Signature, PL_STRING|REP_ISO_LATIN_1,
-		      signature_len, (char*)signature);
-  PL_free(signature);
-
-  return rc;
-}
-
-static foreign_t
-pl_rsa_verify(term_t Public, term_t Type, term_t Enc,
-	    term_t Data, term_t Signature)
-{ unsigned char *data;
-  size_t data_len;
-  RSA *key;
-  unsigned char *signature;
-  size_t signature_len;
-  int rc;
-  int type;
-
-  if ( !get_enc_text(Data, Enc, &data_len, &data) ||
-       !recover_public_key(Public, &key) ||
-       !get_digest_type(Type, &type) ||
-       !PL_get_nchars(Signature, &signature_len, (char**)&signature, CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION) )
-    return FALSE;
-
-  rc = RSA_verify(type,
-                  data, (unsigned int)data_len,
-                  signature, (unsigned int)signature_len, key);
-  RSA_free(key);
-  if ( rc != 1 )
-  { return raise_ssl_error(ERR_get_error());
-  }
-  return 1;
-}
-
 
 static foreign_t
 pl_ssl_debug(term_t level)
@@ -2227,120 +1757,6 @@ pl_ssl_peer_certificate(term_t stream_t, term_t Cert)
   return FALSE;
 }
 
-#ifndef HAVE_EVP_CIPHER_CTX_RESET
-#define EVP_CIPHER_CTX_reset(C) EVP_CIPHER_CTX_init(C)
-#endif
-
-static foreign_t
-pl_evp_decrypt(term_t ciphertext_t, term_t algorithm_t,
-	       term_t key_t, term_t iv_t, term_t plaintext_t,
-	       term_t options_t)
-{ EVP_CIPHER_CTX* ctx = NULL;
-  const EVP_CIPHER *cipher;
-  char* key;
-  char* iv;
-  char* ciphertext;
-  size_t cipher_length;
-  int plain_length;
-  char* algorithm;
-  char* plaintext;
-  int cvt_flags = CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION;
-  int rep = REP_UTF8;
-  int padding = 1;
-
-  if ( !parse_options(options_t, EVP_MODE, &rep, &padding))
-    return FALSE;
-
-  if ( !PL_get_chars(key_t, &key, cvt_flags) ||
-       !PL_get_chars(iv_t, &iv, cvt_flags) ||
-       !PL_get_nchars(ciphertext_t, &cipher_length, &ciphertext, cvt_flags) ||
-       !PL_get_chars(algorithm_t, &algorithm, cvt_flags) )
-    return FALSE;
-
-  if ( (cipher = EVP_get_cipherbyname(algorithm)) == NULL )
-    return PL_domain_error("cipher", algorithm_t);
-  if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
-    return FALSE;
-
-  EVP_CIPHER_CTX_reset(ctx);
-  EVP_DecryptInit_ex(ctx, cipher, NULL,
-		     (const unsigned char*)key, (const unsigned char*)iv);
-  EVP_CIPHER_CTX_set_padding(ctx, padding);
-  plaintext = PL_malloc(cipher_length + EVP_CIPHER_block_size(cipher));
-  if ( EVP_DecryptUpdate(ctx, (unsigned char*)plaintext, &plain_length,
-			 (unsigned char*)ciphertext, cipher_length) == 1 )
-  { int last_chunk = plain_length;
-    int rc;
-    rc = EVP_DecryptFinal_ex(ctx, (unsigned char*)(plaintext + plain_length),
-                              &last_chunk);
-    EVP_CIPHER_CTX_free(ctx);
-    ERR_print_errors_fp(stderr);
-    rc &= PL_unify_chars(plaintext_t, rep | PL_STRING, plain_length + last_chunk,
-                         plaintext);
-    PL_free(plaintext);
-    return rc;
-  }
-
-  PL_free(plaintext);
-  EVP_CIPHER_CTX_free(ctx);
-
-  return FALSE;
-}
-
-static foreign_t
-pl_evp_encrypt(term_t plaintext_t, term_t algorithm_t,
-               term_t key_t, term_t iv_t, term_t ciphertext_t,
-	       term_t options_t)
-{ EVP_CIPHER_CTX* ctx = NULL;
-  const EVP_CIPHER *cipher;
-  char* key;
-  char* iv;
-  char* ciphertext;
-  int cipher_length;
-  char* algorithm;
-  char* plaintext;
-  size_t plain_length;
-  int cvt_flags = CVT_ATOM|CVT_STRING|CVT_LIST|CVT_EXCEPTION;
-  int rep = REP_UTF8;
-
-  if ( !parse_options(options_t, EVP_MODE, &rep, NULL))
-    return FALSE;
-
-  if ( !PL_get_chars(key_t, &key, cvt_flags) ||
-       !PL_get_chars(iv_t, &iv, cvt_flags) ||
-       !PL_get_nchars(plaintext_t, &plain_length, &plaintext, cvt_flags | rep) ||
-       !PL_get_chars(algorithm_t, &algorithm, cvt_flags) )
-    return FALSE;
-
-  if ( (cipher = EVP_get_cipherbyname(algorithm)) == NULL )
-    return PL_domain_error("cipher", algorithm_t);
-  if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
-    return FALSE;
-
-  EVP_CIPHER_CTX_reset(ctx);
-  EVP_EncryptInit_ex(ctx, cipher, NULL,
-		     (const unsigned char*)key, (const unsigned char*)iv);
-
-  ciphertext = PL_malloc(plain_length + EVP_CIPHER_block_size(cipher));
-  if ( EVP_EncryptUpdate(ctx, (unsigned char*)ciphertext, &cipher_length,
-                         (unsigned char*)plaintext, plain_length) == 1 )
-  { int last_chunk;
-    int rc;
-
-    EVP_EncryptFinal_ex(ctx, (unsigned char*)(ciphertext + cipher_length),
-			&last_chunk);
-    EVP_CIPHER_CTX_free(ctx);
-    rc = PL_unify_chars(ciphertext_t,  PL_STRING|REP_ISO_LATIN_1,
-			cipher_length + last_chunk, ciphertext);
-    PL_free(ciphertext);
-    return rc;
-  }
-
-  PL_free(ciphertext);
-  EVP_CIPHER_CTX_free(ctx);
-
-  return FALSE;
-}
 
 		 /*******************************
 		 *	     INSTALL		*
@@ -2378,27 +1794,12 @@ install_ssl4pl(void)
   ATOM_tlsv1_1              = PL_new_atom("tlsv1_1");
   ATOM_tlsv1_2              = PL_new_atom("tlsv1_2");
   ATOM_minus                = PL_new_atom("-");
-  ATOM_text                 = PL_new_atom("text");
-  ATOM_octet                = PL_new_atom("octet");
-  ATOM_utf8                 = PL_new_atom("utf8");
   ATOM_require_crl          = PL_new_atom("require_crl");
   ATOM_crl                  = PL_new_atom("crl");
-  ATOM_sha1                 = PL_new_atom("sha1");
-  ATOM_sha224               = PL_new_atom("sha224");
-  ATOM_sha256               = PL_new_atom("sha256");
-  ATOM_sha384               = PL_new_atom("sha384");
-  ATOM_sha512               = PL_new_atom("sha512");
-  ATOM_pkcs                 = PL_new_atom("pkcs");
-  ATOM_pkcs_oaep            = PL_new_atom("pkcs_oaep");
-  ATOM_none                 = PL_new_atom("none");
-  ATOM_block                = PL_new_atom("block");
-  ATOM_encoding             = PL_new_atom("encoding");
-  ATOM_padding              = PL_new_atom("padding");
 
   FUNCTOR_error2            = PL_new_functor(PL_new_atom("error"), 2);
   FUNCTOR_ssl_error4        = PL_new_functor(PL_new_atom("ssl_error"), 4);
   FUNCTOR_permission_error3 = PL_new_functor(PL_new_atom("permission_error"), 3);
-  FUNCTOR_ip4               = PL_new_functor(PL_new_atom("ip"), 4);
   FUNCTOR_version1          = PL_new_functor(PL_new_atom("version"), 1);
   FUNCTOR_notbefore1        = PL_new_functor(PL_new_atom("notbefore"), 1);
   FUNCTOR_notafter1         = PL_new_functor(PL_new_atom("notafter"), 1);
@@ -2440,15 +1841,7 @@ install_ssl4pl(void)
   PL_register_foreign("load_certificate",2,pl_load_certificate,      0);
   PL_register_foreign("load_private_key",3,pl_load_private_key,      0);
   PL_register_foreign("load_public_key", 2,pl_load_public_key,      0);
-  PL_register_foreign("rsa_private_decrypt", 4, pl_rsa_private_decrypt, 0);
-  PL_register_foreign("rsa_private_encrypt", 4, pl_rsa_private_encrypt, 0);
-  PL_register_foreign("rsa_public_decrypt", 4, pl_rsa_public_decrypt, 0);
-  PL_register_foreign("rsa_public_encrypt", 4, pl_rsa_public_encrypt, 0);
   PL_register_foreign("system_root_certificates", 1, pl_system_root_certificates, 0);
-  PL_register_foreign("rsa_sign", 5, pl_rsa_sign, 0);
-  PL_register_foreign("rsa_verify", 5, pl_rsa_verify, 0);
-  PL_register_foreign("evp_decrypt",        6, pl_evp_decrypt, 0);
-  PL_register_foreign("evp_encrypt",        6, pl_evp_encrypt, 0);
 
   /*
    * Initialize ssllib

--- a/ssllib.c
+++ b/ssllib.c
@@ -2347,3 +2347,25 @@ ssl_deb(int level, char *fmt, ...)
 #endif
 }
 
+#if !defined(HAVE_OPENSSL_ZALLOC) && !defined(OPENSSL_zalloc)
+static void *
+OPENSSL_zalloc(size_t num)
+{ void *ret = OPENSSL_malloc(num);
+  if (ret != NULL)
+    memset(ret, 0, num);
+  return ret;
+}
+#endif
+
+#ifndef HAVE_EVP_MD_CTX_FREE
+void
+EVP_MD_CTX_free(EVP_MD_CTX *ctx)
+{ EVP_MD_CTX_cleanup(ctx);
+  OPENSSL_free(ctx);
+}
+
+EVP_MD_CTX *
+EVP_MD_CTX_new(void)
+{ return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
+}
+#endif

--- a/ssllib.h
+++ b/ssllib.h
@@ -235,5 +235,10 @@ void            ssl_deb          (int level, char *fmt, ...);
 extern BIO_METHOD *bio_read_method();
 extern BIO_METHOD *bio_write_method();
 
+#ifndef HAVE_EVP_MD_CTX_FREE
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+EVP_MD_CTX *EVP_MD_CTX_new(void);
+#endif
+
 #endif
 

--- a/test_ssl.pl
+++ b/test_ssl.pl
@@ -49,6 +49,7 @@
 
 :- use_module(library(plunit)).
 :- use_module(library(ssl)).
+:- use_module(library(crypto)).
 :- use_module(library(debug)).
 :- use_module(library(error)).
 :- use_module(library(readutil)).


### PR DESCRIPTION
This is my suggestion, as discussed in #76.

It passes all tests with OpenSSL 1.1.0 as well as earlier versions.

Please review and merge if applicable. It will be a pleasure for me to add more bindings to `library(crypto)` in the future.