### PR TITLE
ENHANCED: Completely disentangle library(crypto) from libssl.so

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -22,7 +22,7 @@ LIBPL=		@PLTARGETS@
 TARGETS=	@TARGETS@
 EXAMPLES=	client.pl server.pl https.pl
 
-SSLOBJ=		crypto4pl.o ssl4pl.o ssllib.o ../clib/nonblockio.o ../clib/error.o
+SSLOBJ=		crypto4pl.o cryptolib.o ssl4pl.o ssllib.o ../clib/nonblockio.o ../clib/error.o
 
 all:		$(TARGETS)
 

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -37,12 +37,7 @@
 #include <SWI-Prolog.h>
 #include <assert.h>
 #include <string.h>
-#include "ssllib.h"
-#include <openssl/md5.h>
-
-#ifdef _REENTRANT
-#include <pthread.h>
-#endif
+#include "cryptolib.h"
 
 static atom_t ATOM_sslv23;
 static atom_t ATOM_minus;			/* "-" */
@@ -773,22 +768,9 @@ install_crypto4pl(void)
   PL_register_foreign("evp_decrypt", 6, pl_evp_decrypt, 0);
   PL_register_foreign("evp_encrypt", 6, pl_evp_encrypt, 0);
   PL_register_foreign("md5_hash", 3, pl_md5_hash, 0);
-
-  /*
-   * Initialize ssllib
-   */
-  (void) ssl_lib_init();
-
-  PL_set_prolog_flag("ssl_library_version", PL_ATOM,
-#ifdef HAVE_OPENSSL_VERSION
-		     OpenSSL_version(OPENSSL_VERSION)
-#else
-		     SSLeay_version(SSLEAY_VERSION)
-#endif
-		     );
 }
 
 install_t
 uninstall_crypto4pl(void)
-{ ssl_lib_exit();
+{
 }

--- a/cryptolib.c
+++ b/cryptolib.c
@@ -1,0 +1,165 @@
+/*  Part of SWI-Prolog
+
+    Author:        Markus Triska
+    E-mail:        triska@metalevel.at
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2004-2016, SWI-Prolog Foundation
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <config.h>
+#include <string.h>
+#include "cryptolib.h"
+
+#if !defined(HAVE_OPENSSL_ZALLOC) && !defined(OPENSSL_zalloc)
+static void *
+OPENSSL_zalloc(size_t num)
+{ void *ret = OPENSSL_malloc(num);
+  if (ret != NULL)
+    memset(ret, 0, num);
+  return ret;
+}
+#endif
+
+#ifndef HAVE_EVP_MD_CTX_FREE
+void
+EVP_MD_CTX_free(EVP_MD_CTX *ctx)
+{ EVP_MD_CTX_cleanup(ctx);
+  OPENSSL_free(ctx);
+}
+
+EVP_MD_CTX *
+EVP_MD_CTX_new(void)
+{ return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
+}
+#endif
+
+
+/***********************************************************************
+ * Warning, error and debug reporting
+ ***********************************************************************/
+
+/**
+ * ssl_error_term(long ex) returns a Prolog term representing the SSL
+ * error.  If there is already a pending exception, this is returned.
+ *
+ */
+int
+ssl_error_term(long e)
+{ term_t ex;
+  char buffer[256];
+  char* colon;
+  char *component[5] = {NULL, "unknown", "unknown", "unknown", "unknown"};
+  int n = 0;
+
+  if ( (ex=PL_exception(0)) )
+    return ex;					/* already pending exception */
+
+  ERR_error_string_n(e, buffer, 256);
+
+  /*
+   * Disect the following error string:
+   *
+   * error:[error code]:[library name]:[function name]:[reason string]
+   */
+  if ( (ex=PL_new_term_ref()) )
+  { for (colon = buffer, n = 0; n < 5 && colon != NULL; n++)
+    { component[n] = colon;
+      if ((colon = strchr(colon, ':')) == NULL) break;
+      *colon++ = 0;
+    }
+    if ( PL_unify_term(ex,
+		       PL_FUNCTOR, FUNCTOR_error2,
+		       PL_FUNCTOR, FUNCTOR_ssl_error4,
+		       PL_CHARS, component[1],
+		       PL_CHARS, component[2],
+		       PL_CHARS, component[3],
+		       PL_CHARS, component[4],
+		       PL_VARIABLE) )
+    { return ex;
+    }
+  }
+
+  return PL_exception(0);
+}
+
+
+int
+raise_ssl_error(long e)
+{ term_t ex;
+
+  if ( (ex = ssl_error_term(e)) )
+    return PL_raise_exception(ex);
+
+  return FALSE;
+}
+
+
+
+void
+ssl_msg(char *fmt, ...)
+{
+    va_list argpoint;
+
+    va_start(argpoint, fmt);
+	Svfprintf(Soutput, fmt, argpoint);
+    va_end(argpoint);
+}
+
+
+void
+ssl_err(char *fmt, ...)
+{
+    va_list argpoint;
+
+    va_start(argpoint, fmt);
+	Svfprintf(Serror, fmt, argpoint);
+    va_end(argpoint);
+}
+
+
+int
+ssl_set_debug(int level)
+{ return nbio_debug(level);
+}
+
+
+void
+ssl_deb(int level, char *fmt, ...)
+{
+#if DEBUG
+    if ( nbio_debug(-1) >= level )
+    { va_list argpoint;
+
+      fprintf(stderr, "Debug: ");
+      va_start(argpoint, fmt);
+      Svfprintf(Serror, fmt, argpoint);
+      va_end(argpoint);
+    }
+#endif
+}

--- a/cryptolib.h
+++ b/cryptolib.h
@@ -1,0 +1,97 @@
+/*  Part of SWI-Prolog
+
+    Author:        Markus Triska
+    E-mail:        triska@metalevel.at
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2004-2016, SWI-Prolog Foundation
+                              VU University Amsterdam
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef CRYPTOLIBH__
+#define CRYTPOLIBH__
+
+#include <openssl/rsa.h>
+#include <openssl/dsa.h>
+#include <openssl/x509.h>
+#include <openssl/md5.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+#ifdef __SWI_PROLOG__
+#include <SWI-Stream.h>
+#include <SWI-Prolog.h>
+
+#ifdef __WINDOWS__
+#include <windows.h>
+#include <wincrypt.h>
+#endif
+#if defined(HAVE_SECURITY_SECURITY_H) && defined(HAVE_KSECCLASS) /*__APPLE__*/
+#include <Security/Security.h>
+#else
+#undef HAVE_SECURITY_SECURITY_H
+#endif
+#define perror(x) Sdprintf("%s: %s\n", x, strerror(errno));
+
+/*
+ * Remap socket related calls to nonblockio library
+ */
+#include "../clib/nonblockio.h"
+#define closesocket     nbio_closesocket
+#else   /* __SWI_PROLOG__ */
+#define Soutput         stdout
+#define Serror          stderr
+#define Svfprintf       vfprintf
+static int PL_handle_signals(void) { return 0; }
+#ifndef __WINDOWS__
+#define closesocket	close
+#endif
+#endif  /* __SWI_PROLOG__ */
+
+
+#ifndef DEBUG
+#define DEBUG 1
+#endif
+
+#ifndef HAVE_EVP_MD_CTX_FREE
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+EVP_MD_CTX *EVP_MD_CTX_new(void);
+#endif
+
+extern functor_t FUNCTOR_error2;
+extern functor_t FUNCTOR_ssl_error4;
+
+int             raise_ssl_error(long e);
+int             ssl_error_term(long e);
+
+void            ssl_msg          (char *fmt, ...);
+void            ssl_err          (char *fmt, ...);
+int             ssl_set_debug    (int level);
+void            ssl_deb          (int level, char *fmt, ...);
+
+#endif

--- a/ssllib.h
+++ b/ssllib.h
@@ -61,11 +61,8 @@ typedef enum
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/bn.h>
-#include <openssl/evp.h>
 #include <openssl/dh.h>
-#include <openssl/rsa.h>
-#include <openssl/dsa.h>
-#include <openssl/x509.h>
+#include "cryptolib.h"
 
 typedef struct X509_list
 { struct X509_list *next;
@@ -198,7 +195,6 @@ BOOL            ssl_set_peer_cert(PL_SSL *config, BOOL required);
 BOOL            ssl_set_close_parent(PL_SSL *config, int closeparent);
 BOOL            ssl_set_close_notify(PL_SSL *config, BOOL close_notify);
 void            ssl_set_method_options(PL_SSL *config, int options);
-int		raise_ssl_error(long e);
 X509_list *	system_root_certificates(void);
 
 BOOL            ssl_set_cb_cert_verify
@@ -227,18 +223,8 @@ BOOL            ssl_set_cb_sni
                                   void *
                                   );
 
-void            ssl_msg          (char *fmt, ...);
-void            ssl_err          (char *fmt, ...);
-int		ssl_set_debug	 (int level);
-void            ssl_deb          (int level, char *fmt, ...);
-
 extern BIO_METHOD *bio_read_method();
 extern BIO_METHOD *bio_write_method();
-
-#ifndef HAVE_EVP_MD_CTX_FREE
-void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
-EVP_MD_CTX *EVP_MD_CTX_new(void);
-#endif
 
 #endif
 


### PR DESCRIPTION
This allows you to use the cryptographic predicates without loading
the full SSL library.