### PR TITLE
ENHANCED: Share thread safety code in cryptolib.c

### DIFF
--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -768,9 +768,15 @@ install_crypto4pl(void)
   PL_register_foreign("evp_decrypt", 6, pl_evp_decrypt, 0);
   PL_register_foreign("evp_encrypt", 6, pl_evp_encrypt, 0);
   PL_register_foreign("md5_hash", 3, pl_md5_hash, 0);
+
+  /*
+   * Initialize crypto library
+   */
+  (void) crypto_lib_init();
+
 }
 
 install_t
 uninstall_crypto4pl(void)
-{
+{ crypto_lib_exit();
 }

--- a/cryptolib.c
+++ b/cryptolib.c
@@ -34,6 +34,10 @@
 
 #include <config.h>
 #include <string.h>
+#ifdef _REENTRANT
+#include <pthread.h>
+#endif
+
 #include "cryptolib.h"
 
 #if !defined(HAVE_OPENSSL_ZALLOC) && !defined(OPENSSL_zalloc)
@@ -162,4 +166,150 @@ ssl_deb(int level, char *fmt, ...)
       va_end(argpoint);
     }
 #endif
+}
+
+
+                /*******************************
+                *            THREADING         *
+                *******************************/
+
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+OpenSSL is only thread-safe as of version 1.1.0.
+
+For earlier versions, we need to install the hooks below. This code is
+based on mttest.c distributed with the OpenSSL library.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifdef _REENTRANT
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+static pthread_mutex_t *lock_cs;
+static long *lock_count;
+static void (*old_locking_callback)(int, int, const char*, int) = NULL;
+#ifdef HAVE_CRYPTO_THREADID_GET_CALLBACK
+static void (*old_id_callback)(CRYPTO_THREADID*) = NULL;
+#else
+static unsigned long (*old_id_callback)(void) = NULL;
+#endif
+
+static void
+pthreads_locking_callback(int mode, int type, const char *file, int line)
+{ if (mode & CRYPTO_LOCK)
+  { pthread_mutex_lock(&(lock_cs[type]));
+    lock_count[type]++;
+  } else
+  { pthread_mutex_unlock(&(lock_cs[type]));
+  }
+}
+
+
+/*  From OpenSSL manual:
+
+    id_function(void) is a function that returns a thread ID. It is not
+    needed on Windows nor on platforms where getpid() returns a different
+    ID for each thread (most notably Linux).
+
+    As for pthreads_win32 version 2, the thread identifier is no longer
+    integral, we are going to test this claim from the manual
+
+    JW: I don't think getpid() returns different thread ids on Linux any
+    longer, nor on many other Unix systems. Maybe we should use
+    PL_thread_self()?
+*/
+
+#ifndef __WINDOWS__
+#ifdef HAVE_CRYPTO_THREADID_SET_CALLBACK
+static void
+pthreads_thread_id(CRYPTO_THREADID* id)
+{ CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
+}
+#else
+static unsigned long
+pthreads_thread_id(void)
+{ unsigned long ret;
+
+  ret=(unsigned long)pthread_self();
+  return(ret);
+}
+#endif /* OpenSSL 1.0.0 */
+#endif /* WINDOWS */
+#endif /* OpenSSL 1.1.0 */
+
+void
+crypto_thread_exit(void* ignored)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifdef HAVE_ERR_REMOVE_THREAD_STATE
+  ERR_remove_thread_state(0);
+#elif defined(HAVE_ERR_REMOVE_STATE)
+  ERR_remove_state(0);
+#else
+#error "Do not know how to remove SSL error state"
+#endif
+#endif /* ERR_remove_(thread)_state is deprecated in OpenSSL >= 1.1.0 */
+}
+
+int
+crypto_lib_init(void)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+  int i;
+  lock_cs = OPENSSL_malloc(CRYPTO_num_locks() * sizeof(pthread_mutex_t));
+  lock_count = OPENSSL_malloc(CRYPTO_num_locks() * sizeof(long));
+  for (i=0; i<CRYPTO_num_locks(); i++)
+  { lock_count[i]=0;
+    pthread_mutex_init(&(lock_cs[i]), NULL);
+  }
+#ifdef HAVE_CRYPTO_THREADID_GET_CALLBACK
+  old_id_callback = CRYPTO_THREADID_get_callback();
+#else
+  old_id_callback = CRYPTO_get_id_callback();
+#endif
+  old_locking_callback = CRYPTO_get_locking_callback();
+#ifndef __WINDOWS__
+#ifdef HAVE_CRYPTO_THREADID_SET_CALLBACK
+  CRYPTO_THREADID_set_callback(pthreads_thread_id);
+#else
+  CRYPTO_set_id_callback(pthreads_thread_id);
+#endif
+#endif
+  CRYPTO_set_locking_callback(pthreads_locking_callback);
+#endif
+  PL_thread_at_exit(crypto_thread_exit, NULL, TRUE);
+  return TRUE;
+}
+
+#else /*_REENTRANT*/
+
+int
+crypto_lib_init(void)
+{ return FALSE;
+}
+
+#endif /*_REENTRANT*/
+
+
+int
+crypto_lib_exit(void)
+/*
+ * One-time library exit calls
+ */
+{
+/*
+ * If the module is being unloaded, we should remove callbacks pointing to
+ * our address space
+ */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifdef _REENTRANT
+#ifndef __WINDOWS__
+#ifdef HAVE_CRYPTO_THREADID_SET_CALLBACK
+    CRYPTO_THREADID_set_callback(old_id_callback);
+#else
+    CRYPTO_set_id_callback(old_id_callback);
+#endif
+#endif
+    CRYPTO_set_locking_callback(old_locking_callback);
+#endif
+#endif
+    return 0;
 }

--- a/cryptolib.h
+++ b/cryptolib.h
@@ -86,6 +86,9 @@ EVP_MD_CTX *EVP_MD_CTX_new(void);
 extern functor_t FUNCTOR_error2;
 extern functor_t FUNCTOR_ssl_error4;
 
+int             crypto_lib_init(void);
+int             crypto_lib_exit(void);
+
 int             raise_ssl_error(long e);
 int             ssl_error_term(long e);
 

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -40,10 +40,6 @@
 #include <string.h>
 #include "ssllib.h"
 
-#ifdef _REENTRANT
-#include <pthread.h>
-#endif
-
 static atom_t ATOM_server;
 static atom_t ATOM_client;
 static atom_t ATOM_password;
@@ -1820,10 +1816,7 @@ install_ssl4pl(void)
   PL_register_foreign("load_public_key", 2,pl_load_public_key,      0);
   PL_register_foreign("system_root_certificates", 1, pl_system_root_certificates, 0);
 
-  /*
-   * Initialize ssllib
-   */
-  (void) ssl_lib_init();
+  ssl_lib_init();
 
   PL_set_prolog_flag("ssl_library_version", PL_ATOM,
 #ifdef HAVE_OPENSSL_VERSION

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -1735,40 +1735,42 @@ pl_ssl_peer_certificate(term_t stream_t, term_t Cert)
 		 *	     INSTALL		*
 		 *******************************/
 
+#define MKATOM(n) ATOM_ ## n = PL_new_atom(#n);
 
 install_t
 install_ssl4pl(void)
-{ ATOM_server               = PL_new_atom("server");
-  ATOM_client               = PL_new_atom("client");
-  ATOM_password             = PL_new_atom("password");
-  ATOM_host                 = PL_new_atom("host");
-  ATOM_cert                 = PL_new_atom("cert");
-  ATOM_peer_cert            = PL_new_atom("peer_cert");
-  ATOM_cacert_file          = PL_new_atom("cacert_file");
-  ATOM_certificate_file     = PL_new_atom("certificate_file");
-  ATOM_certificate          = PL_new_atom("certificate");
-  ATOM_key_file             = PL_new_atom("key_file");
-  ATOM_key                  = PL_new_atom("key");
-  ATOM_pem_password_hook    = PL_new_atom("pem_password_hook");
-  ATOM_cert_verify_hook     = PL_new_atom("cert_verify_hook");
-  ATOM_close_parent         = PL_new_atom("close_parent");
-  ATOM_close_notify         = PL_new_atom("close_notify");
-  ATOM_disable_ssl_methods  = PL_new_atom("disable_ssl_methods");
-  ATOM_min_protocol_version = PL_new_atom("min_protocol_version");
-  ATOM_max_protocol_version = PL_new_atom("max_protocol_version");
-  ATOM_cipher_list          = PL_new_atom("cipher_list");
-  ATOM_ecdh_curve           = PL_new_atom("ecdh_curve");
-  ATOM_root_certificates    = PL_new_atom("root_certificates");
-  ATOM_sni_hook             = PL_new_atom("sni_hook");
-  ATOM_sslv2                = PL_new_atom("sslv2");
-  ATOM_sslv23               = PL_new_atom("sslv23");
-  ATOM_sslv3                = PL_new_atom("sslv3");
-  ATOM_tlsv1                = PL_new_atom("tlsv1");
-  ATOM_tlsv1_1              = PL_new_atom("tlsv1_1");
-  ATOM_tlsv1_2              = PL_new_atom("tlsv1_2");
+{ MKATOM(server);
+  MKATOM(client);
+  MKATOM(password);
+  MKATOM(host);
+  MKATOM(cert);
+  MKATOM(peer_cert);
+  MKATOM(cacert_file);
+  MKATOM(certificate_file);
+  MKATOM(certificate);
+  MKATOM(key_file);
+  MKATOM(key);
+  MKATOM(pem_password_hook);
+  MKATOM(cert_verify_hook);
+  MKATOM(close_parent);
+  MKATOM(close_notify);
+  MKATOM(disable_ssl_methods);
+  MKATOM(min_protocol_version);
+  MKATOM(max_protocol_version);
+  MKATOM(cipher_list);
+  MKATOM(ecdh_curve);
+  MKATOM(root_certificates);
+  MKATOM(sni_hook);
+  MKATOM(sslv2);
+  MKATOM(sslv23);
+  MKATOM(sslv3);
+  MKATOM(tlsv1);
+  MKATOM(tlsv1_1);
+  MKATOM(tlsv1_2);
+  MKATOM(require_crl);
+  MKATOM(crl);
+
   ATOM_minus                = PL_new_atom("-");
-  ATOM_require_crl          = PL_new_atom("require_crl");
-  ATOM_crl                  = PL_new_atom("crl");
 
   FUNCTOR_error2            = PL_new_functor(PL_new_atom("error"), 2);
   FUNCTOR_ssl_error4        = PL_new_functor(PL_new_atom("ssl_error"), 4);

--- a/ssllib.h
+++ b/ssllib.h
@@ -172,7 +172,6 @@ int             ssl_accept       (PL_SSL *config, void *addr, socklen_t *addrlen
 int             ssl_connect      (PL_SSL *config);
 ssize_t         ssl_read         (void *handle, char *buf, size_t size);
 ssize_t         ssl_write        (void *handle, char *buf, size_t size);
-int		ssl_thread_setup (void);
 
 char *          ssl_set_host     (PL_SSL *config, const char *host);
 int             ssl_set_port     (PL_SSL *config, int port);


### PR DESCRIPTION
In older OpenSSL versions, this is necessary to make `library(crypto)` thread-safe.