### PR TITLE
New hooks: https:ssl_server_create_hook/2 and https:ssl_server_open_client_hook/2

### DIFF
--- a/http_ssl_plugin.pl
+++ b/http_ssl_plugin.pl
@@ -76,15 +76,15 @@ SWI-Prolog installation directory.
 %   @see thread_httpd:accept_hook/2 handles the corresponding accept
 
 thread_httpd:make_socket_hook(Port, M:Options0, Options) :-
-    memberchk(ssl(SSLOptions), Options0),
+    select(ssl(SSLOptions), Options0, Options1),
     !,
-    make_socket(Port, Socket, Options0),
+    make_socket(Port, Socket, Options1),
     ssl_context(server,
                 SSL0,
                 M:[ close_parent(true)
                   | SSLOptions
                   ]),
-    (   http:ssl_server_create_hook(SSL0, SSL, Options0)
+    (   http:ssl_server_create_hook(SSL0, SSL, Options1)
     ->  true
     ;   SSL = SSL0
     ),
@@ -92,7 +92,7 @@ thread_httpd:make_socket_hook(Port, M:Options0, Options) :-
     Options = [ queue(Queue),
                 tcp_socket(Socket),
                 ssl_instance(SSL)
-              | Options0
+              | Options1
               ].
 
 make_socket(_Port, Socket, Options) :-

--- a/ssl.doc
+++ b/ssl.doc
@@ -323,7 +323,7 @@ additional command~line arguments:
   \const{--password} command line options.
 \end{itemize}
 
-Below is an example that uses the self-signed demo certificates
+Here is an example that uses the self-signed demo certificates
 distributed with the SSL package. As is typical for publicly
 accessible HTTPS~servers, this version does \textit{not} require a
 certificate from the~client:
@@ -342,6 +342,27 @@ https_server(Port, Options) :-
                     | Options
                     ]).
 \end{code}
+
+There are two \jargon{hooks} that let you extend HTTPS servers with
+custom definitions:
+
+\begin{itemize}
+\item \texttt{http:ssl_server_create_hook(+SSL0, -SSL, +Options)}:
+  This extensible predicate is called exactly \textit{once}, after
+  creating an HTTPS~server with Options. If this predicate succeeds,
+  \texttt{SSL} is the~context that is used for negotiating all new
+  connections.  Otherwise, \texttt{SSL0} is used, which is the context
+  that was created with the given options.
+\item \texttt{http:ssl_server_open_client_hook(+SSL0, -SSL,
+  +Options)}: This predicate is called before \textit{each} connection
+  that the server negotiates with a client. If this predicate
+  succeeds, \texttt{SSL} is the context that is used for the
+  new~connection.  Otherwise, \texttt{SSL0} is~used, which is the
+  context that was created when launching the~server.
+\end{itemize}
+
+Important use cases of these hooks are running dual-stack RSA/ECDSA
+servers, and updating certificates while the server keeps running.
 
 The example file \file{https.pl} also provides a server that
 \textit{does} require the client to show its certificate. This

--- a/ssl.doc
+++ b/ssl.doc
@@ -309,7 +309,7 @@ HTTPS~server:
   started by using the command line argument~\const{--https}.
 \end{itemize}
 
-At least two items must be specified as, respectively, options or
+Two items are typically specified as, respectively, options or
 additional command~line arguments:
 
 \begin{itemize}

--- a/ssl.pl
+++ b/ssl.pl
@@ -47,7 +47,7 @@
             ssl_accept/3,               % +Config, -Socket, -Peer
             ssl_open/3,                 % +Config, -Read, -Write
             ssl_open/4,                 % +Config, +Socket, -Read, -Write
-            ssl_add_certificate_key/3,  % +Config, +String, +String
+            ssl_add_certificate_key/4,  % +Config, +Cert, +Key, -Config
             ssl_negotiate/5,            % +Config, +PlainRead, +PlainWrite,
                                         %          -SSLRead,   -SSLWrite
             ssl_peer_certificate/2,     % +Stream, -Certificate
@@ -289,9 +289,9 @@ ssl_context(Role, SSL, Module:Options) :-
     select_option(ssl_method(Method), Options, O1, sslv23),
     '_ssl_context'(Role, SSL, Module:O1, Method).
 
-%!  ssl_add_certificate_key(+SSL, +Certificate, +Key)
+%!  ssl_add_certificate_key(+SSL0, +Certificate, +Key, -SSL)
 %
-%   Add an additional certificate/key pair to the SSL context.
+%   Add an additional certificate/key pair to SSL0, yielding SSL.
 %   Certificate and Key are either strings or atoms that hold the
 %   PEM-encoded certificate plus certificate chain and private key,
 %   respectively. Using strings is preferred for security reasons.
@@ -305,6 +305,15 @@ ssl_context(Role, SSL, Module:Options) :-
 %   versions, this predicate may allow updating the certificate of a
 %   running server. Currently, up to 12 additional certificates
 %   are admissible. This limit may be removed in the future.
+%
+%   @tbd Some configuration properties of SSL0 are currently not yet
+%   retained in SSL. However, all configuration options that can be
+%   specified when using the HTTP Unix daemon are fully handled.
+
+ssl_add_certificate_key(SSL0, Cert, Key, SSL) :-
+    ssl_context(server, SSL, [sni_hook(none)]),
+    '_ssl_init_from_context'(SSL0, SSL),
+    '_ssl_add_certificate_key'(SSL, Cert, Key).
 
 %!  ssl_negotiate(+SSL,
 %!                +PlainRead, +PlainWrite,

--- a/ssl.pl
+++ b/ssl.pl
@@ -311,7 +311,7 @@ ssl_context(Role, SSL, Module:Options) :-
 %   specified when using the HTTP Unix daemon are fully handled.
 
 ssl_add_certificate_key(SSL0, Cert, Key, SSL) :-
-    ssl_context(server, SSL, [sni_hook(none)]),
+    ssl_context(server, SSL, []),
     '_ssl_init_from_context'(SSL0, SSL),
     '_ssl_add_certificate_key'(SSL, Cert, Key).
 

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -2463,16 +2463,6 @@ ssl_use_certificates(PL_SSL *config, term_t options)
 {
   int cert_idx;
 
-  if ( !config->certificate_file &&
-       ( config->num_cert_key_pairs == 0 ) &&
-       !config->cb_sni_pred )
-    return PL_existence_error("certificate", options);
-
-  if ( !config->key_file &&
-       ( config->num_cert_key_pairs == 0 ) &&
-       !config->cb_sni_pred )
-    return PL_existence_error("key", options);
-
   if ( config->certificate_file &&
        SSL_CTX_use_certificate_chain_file(config->ctx,
                                           config->certificate_file) <= 0 )

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -2417,6 +2417,11 @@ ssl_use_certificate(PL_SSL *config, char *certificate, X509 **ret)
   if ( SSL_CTX_use_certificate(config->ctx, certX509) <= 0 )
     return raise_ssl_error(ERR_get_error());
 
+#ifdef SSL_CTX_clear_chain_certs
+  if ( SSL_CTX_clear_chain_certs(config->ctx) <= 0 )
+    return raise_ssl_error(ERR_get_error());
+#endif
+
   while ( (certX509 = PEM_read_bio_X509(bio, NULL, NULL, NULL)) != NULL )
   { if ( SSL_CTX_add0_chain_cert(config->ctx, certX509) <= 0 )
       return raise_ssl_error(ERR_get_error());

--- a/test_ssl.pl
+++ b/test_ssl.pl
@@ -196,7 +196,7 @@ test(cert_mismatch, Msg == 'key values mismatch') :-
 
 % missing certificate (key specified, with and without sni)
 
-test(missing_cert, Msg == existence_error) :-
+test(missing_cert, Msg == 'no certificate assigned') :-
     options_errmsg([key_file('etc/server/server-key.pem'),
                     password(apenoot1)], Msg).
 test(missing_cert, Msg == 'no certificate assigned') :-
@@ -206,7 +206,7 @@ test(missing_cert, Msg == 'no certificate assigned') :-
 
 % missing key (certificate specified, with and without sni)
 
-test(missing_key, Msg == existence_error) :-
+test(missing_key, Msg == 'no private key assigned') :-
     options_errmsg([certificate_file('etc/server/server-cert.pem')], Msg).
 test(missing_key, Msg == 'no private key assigned') :-
     options_errmsg([certificate_file('etc/server/server-cert.pem'),


### PR DESCRIPTION
These hooks let us:

- *exchange* the certificate of a running&nbsp;server
- launch servers with *multiple* certificates
- specify *default* certificates.

Due to their [**logical purity**](https://www.metalevel.at/prolog/purity), all of this is completely *thread-safe*!

To the best of my knowledge, none of the more widely used HTTPS servers lets you do&nbsp;this. In fact, not even OpenSSL&nbsp;itself lets you exchange the certificate of a context in a thread-safe&nbsp;way.

These features are also available when using the HTTP Unix&nbsp;daemon.

Enjoy!