### PR TITLE
ENHANCED: Transfer certificate revocation list when copying a context.

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -303,10 +303,8 @@ ssl_context(Role, SSL, Module:Options) :-
 %   `certificate_key_pairs/1` option. As of OpenSSL 1.0.2, multiple
 %   certificate types with completely independent certificate chains
 %   are supported. If a certificate of the same type is added
-%   repeatedly to a context, the result is undefined. In future
-%   versions, this predicate may allow updating the certificate of a
-%   running server. Currently, up to 12 additional certificates
-%   are admissible. This limit may be removed in the future.
+%   repeatedly to a context, the result is undefined. Currently, up to
+%   12 additional certificates of different types are admissible.
 
 ssl_add_certificate_key(SSL0, Cert, Key, SSL) :-
     ssl_copy_context(SSL0, SSL),

--- a/ssl.pl
+++ b/ssl.pl
@@ -3,7 +3,7 @@
     Author:        Jan van der Steen, Matt Lilley and Jan Wielemaker,
     E-mail:        J.Wielemaker@vu.nl
     WWW:           http://www.swi-prolog.org
-    Copyright (c)  2004-2016, SWI-Prolog Foundation
+    Copyright (c)  2004-2017, SWI-Prolog Foundation
                               VU University Amsterdam
     All rights reserved.
 
@@ -307,10 +307,6 @@ ssl_context(Role, SSL, Module:Options) :-
 %   versions, this predicate may allow updating the certificate of a
 %   running server. Currently, up to 12 additional certificates
 %   are admissible. This limit may be removed in the future.
-%
-%   @tbd Some configuration properties of SSL0 are currently not yet
-%   retained in SSL. However, all configuration options that can be
-%   specified when using the HTTP Unix daemon are fully handled.
 
 ssl_add_certificate_key(SSL0, Cert, Key, SSL) :-
     ssl_copy_context(SSL0, SSL),
@@ -325,10 +321,6 @@ ssl_copy_context(SSL0, SSL) :-
 %   SSL is the same as SSL0, except  that the SNI hook of SSL is Goal.
 %   See  the   sni_hook(:Goal)  option   of  ssl_context/3   for  more
 %   information about this hook.
-%
-%   @tbd Some configuration  properties of SSL0 are  currently not yet
-%   retained in  SSL. However, all  configuration options that  can be
-%   specified when using the HTTP Unix daemon are fully handled.
 
 ssl_set_sni_hook(SSL0, Goal, SSL) :-
     ssl_copy_context(SSL0, SSL),

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -3332,6 +3332,10 @@ pl_ssl_init_from_context(term_t term_old, term_t term_new)
   new->min_protocol        = old->min_protocol;
   new->max_protocol        = old->max_protocol;
 
+  if (old->crl_list)
+    new->crl_list          = sk_X509_CRL_dup(old->crl_list);
+  new->crl_required        = old->crl_required;
+
   ssl_copy_callback(old->cb_cert_verify, &new->cb_cert_verify);
   ssl_copy_callback(old->cb_pem_passwd, &new->cb_pem_passwd);
   ssl_copy_callback(old->cb_sni, &new->cb_sni);
@@ -3371,7 +3375,6 @@ pl_ssl_init_from_context(term_t term_old, term_t term_new)
                             ssl_cb_cert_verify);
 
   new->cert_required         = old->cert_required;
-  new->crl_required          = old->crl_required;
 #ifndef HAVE_X509_CHECK_HOST
   new->hostname_check_status = old->hostname_check_status;
 #endif
@@ -3383,8 +3386,6 @@ pl_ssl_init_from_context(term_t term_old, term_t term_new)
   }
 
   ssl_init_sni(new);
-
-  /* TODO: transfer remaining settings (CRL.) */
 
   return TRUE;
 }


### PR DESCRIPTION
Thus, all properties of the original context are now correctly retained when
using the new predicates ssl_set_sni_hook/3 and ssl_add_certificate_key/4.