### PR TITLE
ADDED: library(crypto): New interface predicates for computing hashes

### DIFF
--- a/crypto.pl
+++ b/crypto.pl
@@ -38,6 +38,8 @@
             crypto_context_new/2,       % -Context, +Options
             crypto_data_context/3,      % +Data, +C0, -C
             crypto_context_hash/2,      % +Context, -Hash
+            crypto_open_hash_stream/3,  % +InStream, -HashStream, +Options
+            crypto_stream_hash/2,       % +HashStream, -Hash
             evp_decrypt/6,              % +CipherText, +Algorithm, +Key, +IV, -PlainText, +Options
             evp_encrypt/6,              % +PlainText, +Algorithm, +Key, +IV, -CipherText, +Options
             rsa_private_decrypt/3,      % +Key, +Ciphertext, -Plaintext
@@ -162,6 +164,34 @@ bytes_hex([H|T]) -->
     },
     [C0,C1],
     bytes_hex(T).
+
+%!  crypto_open_hash_stream(+OrgStream, -HashStream, +Options) is det.
+%
+%   Open a filter stream on OrgStream  that maintains a hash. The hash
+%   can be retrieved at any time using crypto_stream_hash/2. Available
+%   Options in addition to those of crypto_data_hash/3 are:
+%
+%     - close_parent(+Bool)
+%     If `true` (default), closing the filter stream also closes the
+%     original (parent) stream.
+
+crypto_open_hash_stream(OrgStream, HashStream, Options) :-
+    crypto_context_new(Context, Options),
+    '_crypto_open_hash_stream'(OrgStream, HashStream, Context).
+
+
+%!  crypto_stream_hash(+HashStream, -Hash) is det.
+%
+%   Unify  Hash with  a hash  for  the bytes  sent to  or read  from
+%   HashStream.  Note  that  the  hash is  computed  on  the  stream
+%   buffers. If the stream is an  output stream, it is first flushed
+%   and the Digest  represents the hash at the  current location. If
+%   the stream is an input stream  the Digest represents the hash of
+%   the processed input including the already buffered data.
+
+crypto_stream_hash(Stream, Hash) :-
+    '_crypto_stream_context'(Stream, Context),
+    crypto_context_hash(Context, Hash).
 
 
 %!  rsa_private_decrypt(+PrivateKey, +CipherText, -PlainText) is det.


### PR DESCRIPTION
The new predicates `crypto_term_hash/3`, `crypto_file_hash/3` etc. finally make the digest&nbsp;algorithms that are currently available in library(md5) and library(sha) available under a unified interface, by providing bindings to OpenSSL functionality.

Further OpenSSL digest algorithms can be made available easily with this interface.

Please review especially the Prolog **interface** predicates provided by this patch.

I think this interface is simpler than that of `library(sha)`, for example<sup>1</sup>.

These interface predicates subsume existing libraries that ship with SWI and make it easy to provide new digest algorithms in the future. For example, one of the first new additions will be the `BLAKE` hashing algorithms that are available since OpenSSL&nbsp;1.1.0c. I will include them in `library(crypto)` as soon as https://github.com/openssl/openssl/issues/2169 is resolved, i.e., their **names** are finalized in&nbsp;OpenSSL.

I would be grateful for any review. If you like it, I think this will be ready for merging by the end of the week. Until then, I may update the pull request with minor improvements and corrections of all issues I find in the coming&nbsp;days.

----
<sup>1</sup> This is also evidenced by the fact that `library(sha)` itself was unable to use its own interface correctly: For example, the *empty* file *fails* for `file_sha1(EmptyFile, Hash)`, whereas you correctly get with `library(crypto)`:

<pre>
?- crypto_file_hash(empty_file, Hash, <b>[algorithm(sha1)]</b>).
<b>Hash = 'da39a3ee5e6b4b0d3255bfef95601890afd80709'.</b>
</pre>


