### PR TITLE
ADDED: library(crypto): BLAKE digest algorithms, blake2s256 and blake2b512

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -108,6 +108,7 @@ AC_CHECK_FUNCS(X509_CRL_get0_signature X509_get0_signature)
 AC_CHECK_FUNCS(X509_get0_notBefore X509_get0_notAfter)
 AC_CHECK_FUNCS(OpenSSL_version)
 AC_CHECK_FUNCS(EVP_CIPHER_CTX_reset)
+AC_CHECK_FUNCS(EVP_blake2b512 EVP_blake2s256)
 
 if test "x$ac_cv_func_X509_get0_signature" = "xyes"; then
   ac_oldcflags="$CFLAGS"

--- a/crypto.pl
+++ b/crypto.pl
@@ -85,8 +85,9 @@ less general alternatives to `library(crypto)`.
 %   by Options:
 %
 %    * algorithm(+Algorithm)
-%    One of =md5=, =sha1=, =sha224=, =sha256= (default), =sha384= or
-%    =sha512=.
+%    One of =md5=, =sha1=, =sha224=, =sha256= (default), =sha384=,
+%    =sha512=, =blake2s256= or =blake2b512=. The =BLAKE= digest
+%    algorithms require OpenSSL 1.1.0 or greater.
 %    * encoding(+Encoding)
 %    If Data is a sequence of character _codes_, this must be
 %    translated into a sequence of _bytes_, because that is what

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -51,6 +51,8 @@ static atom_t ATOM_sha224;
 static atom_t ATOM_sha256;
 static atom_t ATOM_sha384;
 static atom_t ATOM_sha512;
+static atom_t ATOM_blake2s256;
+static atom_t ATOM_blake2b512;
 
 static atom_t ATOM_pkcs;
 static atom_t ATOM_pkcs_oaep;
@@ -215,6 +217,12 @@ hash_options(term_t options, PL_CRYPTO_CONTEXT *result)
         { result->algorithm = EVP_sha512();
         } else if ( a_algorithm == ATOM_md5 )
         { result->algorithm = EVP_md5();
+#if defined(HAVE_EVP_BLAKE2B512) && defined(HAVE_EVP_BLAKE2S256)
+        } else if ( a_algorithm == ATOM_blake2b512 )
+        {  result->algorithm = EVP_blake2b512();
+        } else if ( a_algorithm == ATOM_blake2s256 )
+        { result->algorithm = EVP_blake2s256();
+#endif
         } else
           return PL_domain_error("algorithm", a);
       } else if ( aname == ATOM_close_parent )
@@ -1212,12 +1220,16 @@ install_crypto4pl(void)
   MKATOM(text);
   MKATOM(octet);
   MKATOM(utf8);
+
   MKATOM(sha1);
   MKATOM(sha224);
   MKATOM(sha256);
   MKATOM(sha384);
   MKATOM(sha512);
   MKATOM(md5);
+  MKATOM(blake2b512);
+  MKATOM(blake2s256);
+
   MKATOM(pkcs);
   MKATOM(pkcs_oaep);
   MKATOM(none);


### PR DESCRIPTION
These algorithms are available when using OpenSSL 1.1.0 or greater.

Any digest algorithms that OpenSSL implements in future versions can
be made available easily through the interface of library(crypto).