### PR TITLE
Finalization for 7.4

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -91,13 +91,18 @@ clientcert:
 # Documentation
 ################################################################
 
-TEXEXTRA=	ssllib.tex crypto.tex saml.tex xmldsig.tex xmlenc.tex
+PUBLICPL=@PL@
+LIBTOTEX=$(PUBLICPL) -q -f ../../man/libtotex.pl -g libtotex --
+
+TEXEXTRA=	ssllib.tex crypto.tex cryptolib.tex \
+		saml.tex xmldsig.tex xmlenc.tex
 $(TEX):		$(TEXEXTRA)
 
 ssllib.tex:	ssl.pl
 		$(PLTOTEX) --out=$@ --section 'library(ssl)'
-crypto.tex:	crypto.pl
-		$(PLTOTEX) --out=$@ --section 'library(crypto)'
+cryptolib.tex:	cryptolib.md crypto.pl
+		mkdir -p summaries.d
+		$(LIBTOTEX) --lib=crypto --module=crypto cryptolib.md
 saml.tex:	saml.pl
 		$(PLTOTEX) --out=$@ --subsection 'library(saml)'
 xmldsig.tex:	xmldsig.pl
@@ -120,7 +125,8 @@ tests/test_certs:
 ################################################################
 
 clean:
-		rm -f *~ *.o *% a.out core config.log ssl.tex crypto.tex
+		rm -f *~ *.o *% a.out core config.log ssl.tex
+		rm -f crypto.tex cryptolib.tex
 		$(RUNTEX) --clean ssl
 
 distclean:	clean

--- a/crypto.doc
+++ b/crypto.doc
@@ -1,0 +1,13 @@
+
+\libdoc{crypto}{Cryptography and authentication library}
+
+\label{sec:crypto}
+
+\begin{tags}
+\tag{author}\href{https://www.metalevel.at}{Markus Triska}
+\tag{author}{Matt Lilley}
+\end{tags}
+
+% remainder, generated from Markdown and PlDoc
+\input{cryptolib.tex}
+

--- a/crypto.pl
+++ b/crypto.pl
@@ -127,8 +127,8 @@ update_hash(In, Context0, Context) :-
 
 %!  crypto_context_new(-Context, +Options) is det.
 %
-%   Context is unified  with the empty context,  taking into account
-%   Options.  The  context can  be used in  crypto_data_hash/4.  For
+%   Context is  unified with  the empty  context, taking  into account
+%   Options.  The  context can be used  in crypto_data_context/3.  For
 %   Options, see crypto_data_hash/3.
 %
 %   @param Context is an opaque pure  Prolog term that is subject to
@@ -203,7 +203,7 @@ crypto_stream_hash(Stream, Hash) :-
     '_crypto_stream_context'(Stream, Context),
     crypto_context_hash(Context, Hash).
 
-%!  ecdsa_sign(+Key, +Data, -Signature, Options)
+%!  ecdsa_sign(+Key, +Data, -Signature, +Options)
 %
 %   Create  an ECDSA  signature for  Data with  EC private  key Key.
 %   Among the most  common cases is signing a hash  that was created

--- a/crypto.pl
+++ b/crypto.pl
@@ -320,7 +320,7 @@ hex_bytes([H1,H2|Hs]) --> [Byte],
 
 %!  rsa_sign(+Key, +Data, -Signature, +Options) is det.
 %
-%   Create an RSA signature for Data.  Options:
+%   Create an RSA signature for Data with private key Key.  Options:
 %
 %     - type(+Type)
 %     SHA algorithm used to compute the digest.  Values are
@@ -360,7 +360,9 @@ rsa_sign(Key, Data0, Signature, Options) :-
 
 %!  rsa_verify(+Key, +Data, +Signature, +Options) is semidet.
 %
-%   Verifies an RSA signature for Data.  Options:
+%   Verify an RSA signature for Data with public key Key.
+%
+%   Options:
 %
 %     - type(+Type)
 %     SHA algorithm used to compute the digest.  Values are

--- a/crypto.pl
+++ b/crypto.pl
@@ -44,10 +44,6 @@
             ecdsa_verify/4,             % +Key, +Data, +Signature, +Options
             evp_decrypt/6,              % +CipherText, +Algorithm, +Key, +IV, -PlainText, +Options
             evp_encrypt/6,              % +PlainText, +Algorithm, +Key, +IV, -CipherText, +Options
-            rsa_private_decrypt/3,      % +Key, +Ciphertext, -Plaintext
-            rsa_private_encrypt/3,      % +Key, +Plaintext, -Ciphertext
-            rsa_public_decrypt/3,       % +Key, +Ciphertext, -Plaintext
-            rsa_public_encrypt/3,       % +Key, +Plaintext, -Ciphertext
             rsa_private_decrypt/4,      % +Key, +Ciphertext, -Plaintext, +Enc
             rsa_private_encrypt/4,      % +Key, +Plaintext, -Ciphertext, +Enc
             rsa_public_decrypt/4,       % +Key, +Ciphertext, -Plaintext, +Enc
@@ -265,10 +261,6 @@ ecdsa_verify(public_key(ec(Private,Public0,Curve)), Data0, Signature0, Options) 
     '_crypto_ecdsa_verify'(ec(Private,Public,Curve), Data, Enc, Signature).
 
 
-%!  rsa_private_decrypt(+PrivateKey, +CipherText, -PlainText) is det.
-%!  rsa_private_encrypt(+PrivateKey, +PlainText, -CipherText) is det.
-%!  rsa_public_decrypt(+PublicKey, +CipherText, -PlainText) is det.
-%!  rsa_public_encrypt(+PublicKey, +PlainText, -CipherText) is det.
 %!  rsa_private_decrypt(+PrivateKey, +CipherText, -PlainText, +Options) is det.
 %!  rsa_private_encrypt(+PrivateKey, +PlainText, -CipherText, +Options) is det.
 %!  rsa_public_decrypt(+PublicKey, +CipherText, -PlainText, +Options) is det.
@@ -298,18 +290,6 @@ ecdsa_verify(public_key(ec(Private,Public0,Curve)), Data0, Signature0, Options) 
 %
 %   @error ssl_error(Code, LibName, FuncName, Reason)   is raised if
 %   there is an error, e.g., if the text is too long for the key.
-
-rsa_private_decrypt(PrivateKey, CipherText, PlainText) :-
-    rsa_private_decrypt(PrivateKey, CipherText, PlainText, [encoding(utf8)]).
-
-rsa_private_encrypt(PrivateKey, PlainText, CipherText) :-
-    rsa_private_encrypt(PrivateKey, PlainText, CipherText, [encoding(utf8)]).
-
-rsa_public_decrypt(PublicKey, CipherText, PlainText) :-
-    rsa_public_decrypt(PublicKey, CipherText, PlainText, [encoding(utf8)]).
-
-rsa_public_encrypt(PublicKey, PlainText, CipherText) :-
-    rsa_public_encrypt(PublicKey, PlainText, CipherText, [encoding(utf8)]).
 
 %!  rsa_sign(+Key, +Data, -Signature, +Options) is det.
 %

--- a/cryptolib.md
+++ b/cryptolib.md
@@ -1,0 +1,86 @@
+## Introduction {#crypto-introduction}
+
+This library provides bindings  to  functionality   of  OpenSSL  that is
+related to cryptography and authentication,   not  necessarily involving
+connections, sockets or streams.
+
+## Hashes and digests {#crypto-hash}
+
+A **hash**, also called **digest**, is  a way to verify the integrity of
+data.  In typical  cases, a hash is significantly shorter  than the data
+itself, and  already miniscule  changes in the  data lead  to completely
+different hashes.
+
+The  hash functionality  of this  library subsumes  and extends  that of
+`library(sha)`, `library(hash_stream)` and `library(md5)` by providing a
+unified interface to all available digest algorithms.
+
+The underlying  OpenSSL library  (`libcrypto`) is dynamically  loaded if
+_either_ `library(crypto)`  or `library(ssl)` are loaded.  Therefore, if
+your application uses `library(ssl)`,  you can use `library(crypto)` for
+hashing without increasing the memory  footprint of your application. In
+other cases, the specialised hashing  libraries are more lightweight but
+less general alternatives to `library(crypto)`.
+
+The most important predicates to compute hashes are:
+
+  * [[crypto_data_hash/3]]
+  * [[crypto_file_hash/3]]
+
+For further reasoning and conversion of digests in hexadecimal notation,
+the following bidirectional relation is provided:
+
+  * [[hex_bytes/2]]
+
+In addition, the  following predicates are provided  for building hashes
+_incrementally_.  This  works  by  first  creating  a  **context**  with
+crypto_context_new/2, then using this context with crypto_data_context/3
+to  incrementally  obtain  further  contexts, and  finally  extract  the
+resulting hash with crypto_context_hash/2.
+
+  * [[crypto_context_new/2]]
+  * [[crypto_data_context/3]]
+  * [[crypto_context_hash/2]]
+
+The following hashing predicates work over _streams_:
+
+  * [[crypto_open_hash_stream/3]]
+  * [[crypto_stream_hash/2]]
+
+## Digital signatures {#crypto-signatures}
+
+A digital **signature**  is a relation between a key  and data that only
+someone who knows the key can compute.
+
+_Signing_ uses  a _private_  key, and _verifying_  a signature  uses the
+corresponding _public_ key of the  signing entity. This library supports
+both  RSA  and ECDSA  signatures.  You  can use  load_private_key/3  and
+load_public_key/2 to load keys from files and streams.
+
+In typical cases, we use this mechanism  to sign the _hash_ of data. See
+[hashing](<#crypto-hash>).  For this  reason,  the following  predicates
+work on the _hexadecimal_ representation of  hashes that is also used by
+crypto_data_hash/3 and related predicates:
+
+  * [[ecdsa_sign/4]]
+  * [[ecdsa_verify/4]]
+  * [[rsa_sign/4]]
+  * [[rsa_verify/4]]
+
+Signatures are also  represented in hexadecimal notation,  and you can
+use hex_bytes/2 to convert them to and from lists of bytes (integers).
+
+## Asymmetric encryption and decryption {#crypto-asymmetric}
+
+The  following  predicates  provide   _asymmetric_  RSA  encryption  and
+decryption.  This  means that the key  that is used for  _encryption_ is
+different from the one used to _decrypt_ the data:
+
+  * [[rsa_private_decrypt/4]]
+
+## Symmetric encryption and decryption {#crypto-symmetric}
+
+The following predicates provide _symmetric_ encryption and decryption:
+
+  * [[evp_decrypt/6]]
+  * [[evp_encrypt/6]]

--- a/test_ssl.pl
+++ b/test_ssl.pl
@@ -136,8 +136,8 @@ test(trip_private_public, In == Out) :-
                 load_certificate(S2, Cert)
               )),
     memberchk(key(PublicKey), Cert),
-    rsa_private_encrypt(PrivateKey, In, Encrypted),
-    rsa_public_decrypt(PublicKey, Encrypted, Out).
+    rsa_private_encrypt(PrivateKey, In, Encrypted, []),
+    rsa_public_decrypt(PublicKey, Encrypted, Out, []).
 test(trip_private_public, In == Out) :-
     numlist(1040, 1060, L),
     string_codes(In, L),
@@ -148,8 +148,8 @@ test(trip_private_public, In == Out) :-
                 load_certificate(S2, Cert)
               )),
     memberchk(key(PublicKey), Cert),
-    rsa_private_encrypt(PrivateKey, In, Encrypted),
-    rsa_public_decrypt(PublicKey, Encrypted, Out).
+    rsa_private_encrypt(PrivateKey, In, Encrypted, []),
+    rsa_public_decrypt(PublicKey, Encrypted, Out, []).
 test(trip_public_private, In == Out) :-
     In = "Hello World!",
     from_file('tests/test_certs/server-key.pem', S1,
@@ -159,8 +159,8 @@ test(trip_public_private, In == Out) :-
                 load_certificate(S2, Cert)
               )),
     memberchk(key(PublicKey), Cert),
-    rsa_public_encrypt(PublicKey, In, Encrypted),
-    rsa_private_decrypt(PrivateKey, Encrypted, Out).
+    rsa_public_encrypt(PublicKey, In, Encrypted, []),
+    rsa_private_decrypt(PrivateKey, Encrypted, Out, []).
 
 :- end_tests(ssl_keys).
 

--- a/xmldsig.pl
+++ b/xmldsig.pl
@@ -225,16 +225,9 @@ key_info(Key, _) :-
 base64_bignum_arg(I, Key, Value) :-
     arg(I, Key, HexModulesString),
     string_codes(HexModulesString, HexModules),
-    phrase(hex_bytes(Bytes), HexModules),
+    hex_bytes(HexModules, Bytes),
     phrase(base64(Bytes), Bytes64),
     string_codes(Value, Bytes64).
-
-hex_bytes([H|T]) -->
-    xdigit(D1), xdigit(D2),
-    !,
-    { H is D1<<4+D2 },
-    hex_bytes(T).
-hex_bytes([]) --> [].
 
 
 signed_xml_dom(ObjectDOM, SDOM, KeyDOM, Signature, SignedDOM, _Options) :-
@@ -271,7 +264,7 @@ xmld_verify_signature(DOM, SignatureDOM, Certificate, Options) :-
                                            [method(CanonicalizationMethod)|Options])),
         crypto_data_hash(C14N, Digest, [algorithm(HashType)]),
         atom_codes(RawSignature, Codes),
-        hash_atom(Codes, HexSignature),
+        hex_bytes(HexSignature, Codes),
         rsa_verify(PublicKey, Digest, HexSignature, [type(HashType)])
     ;   domain_error(supported_signature_algorithm, Algorithm)
     ).

--- a/xmlenc.pl
+++ b/xmlenc.pl
@@ -38,6 +38,7 @@
          [ decrypt_xml/4   % +EncryptedXML, -DecryptedXML, :KeyCallback, +Options
          ]).
 :- use_module(library(ssl)).
+:- use_module(library(crypto)).
 :- use_module(library(sgml)).
 :- use_module(library(base64)).
 :- use_module(library(error)).
@@ -292,27 +293,11 @@ resolve_key(Info, _, _, _):-
     existence_error(usable_key, Info).
 
 
-base64_to_hex(Base64, HexString):-
+base64_to_hex(Base64, Hex):-
     base64(Raw, Base64),
     atom_codes(Raw, Codes),
-    phrase(hex_bytes(HexCodes), Codes),
-    string_codes(HexString, HexCodes).
-
-hex_bytes([A,B|T]) -->
-    [Byte],
-    !,
-    {Hi is (Byte >> 4) /\ 0xf,
-     Lo is Byte /\ 0xf,
-     (  Hi >= 10
-     -> A is 55 + Hi
-     ;  A is 48 + Hi
-     ),
-     (  Lo >= 10
-     -> B is 55 + Lo
-     ;  B is 48 + Lo
-     )},
-    hex_bytes(T).
-hex_bytes([]) --> [].
+    hex_bytes(Hex0, Codes),
+    string_upper(Hex0, Hex).
 
 
 determine_encryption_algorithm(EncryptedData, Algorithm, IVSize):-


### PR DESCRIPTION
This pull request makes the library ready for the stable release:

- 4 mostly superfluous and unused predicates have been removed to simplify the interface and make it more uniform. Use an empty option list instead.
- The new and **bidirectional** predicate `hex_bytes/2` is now available.
- The documentation is now more structured and self-contained, using **Markdown**.

Please review (especially the `mkdir -p summaries.d` that now appears in `Makefile.in` to generate the directory that `libtotex` expects), merge if applicable, and happy 7.4!