### PR TITLE
ADDED: hmac/1 option for all hash predicates of library(crypto).

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -112,6 +112,7 @@ AC_CHECK_FUNCS(i2d_re_X509_tbs)
 AC_CHECK_FUNCS(OpenSSL_version)
 AC_CHECK_FUNCS(EVP_CIPHER_CTX_reset)
 AC_CHECK_FUNCS(EVP_blake2b512 EVP_blake2s256)
+AC_CHECK_FUNCS(HMAC_CTX_new HMAC_CTX_free)
 
 if test "x$ac_cv_func_X509_get0_signature" = "xyes"; then
   ac_oldcflags="$CFLAGS"

--- a/cryptolib.c
+++ b/cryptolib.c
@@ -85,6 +85,16 @@ unify_bytes_hex(term_t t, size_t len, const unsigned char *data)
   return rc;
 }
 
+static char *
+ssl_strdup(const char *s)
+{
+    char *new = NULL;
+
+    if (s != NULL && (new = malloc(strlen(s)+1)) != NULL) {
+        strcpy(new, s);
+    }
+    return new;
+}
 
 
 /***********************************************************************

--- a/cryptolib.md
+++ b/cryptolib.md
@@ -8,8 +8,8 @@ connections, sockets or streams.
 
 A **hash**, also called **digest**, is  a way to verify the integrity of
 data.  In typical  cases, a hash is significantly shorter  than the data
-itself, and  already miniscule  changes in the  data lead  to completely
-different hashes.
+itself,  and already  miniscule changes  in the  data lead  to different
+hashes.
 
 The  hash functionality  of this  library subsumes  and extends  that of
 `library(sha)`, `library(hash_stream)` and `library(md5)` by providing a

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -1556,17 +1556,6 @@ ssl_inspect_status(PL_SSL_INSTANCE *instance, int ssl_ret, status_role role)
   return SSL_PL_ERROR;
 }
 
-static char *
-ssl_strdup(const char *s)
-{
-    char *new = NULL;
-
-    if (s != NULL && (new = malloc(strlen(s)+1)) != NULL) {
-        strcpy(new, s);
-    }
-    return new;
-}
-
 static PL_SSL *
 ssl_new(void)
 /*


### PR DESCRIPTION
A **hash-based message authentication code** (HMAC) can be used to
simultaneously verify the integrity *and* authenticity of data.

The new `hmac(+Key)` option is now available for *all* hash predicates
of `library(crypto)`, enabling HMAC computation with a given key.

This option is a significant generalization of `hmac_sha/4` from
`library(sha)`: Starting with OpenSSL 1.1.0, hash-based MACs are now
available for *all* provided digest algorithms with `library(crypto)`.

`library(xmldsig)` is a use case that needs this functionality.