### PR TITLE
Improve initialisation

### DIFF
--- a/crypto.pl
+++ b/crypto.pl
@@ -85,8 +85,8 @@ less general alternatives to `library(crypto)`.
 %
 %    * algorithm(+Algorithm)
 %    One of =md5=, =sha1=, =sha224=, =sha256= (default), =sha384=,
-%    =sha512=, =blake2s256= or =blake2b512=. The =BLAKE= digest
-%    algorithms require OpenSSL 1.1.0 or greater.
+%    =sha512=, =ripemd160=, =blake2s256= or =blake2b512=. The =BLAKE=
+%    digest algorithms require OpenSSL 1.1.0 or greater.
 %    * encoding(+Encoding)
 %    If Data is a sequence of character _codes_, this must be
 %    translated into a sequence of _bytes_, because that is what

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -54,6 +54,7 @@ static atom_t ATOM_sha384;
 static atom_t ATOM_sha512;
 static atom_t ATOM_blake2s256;
 static atom_t ATOM_blake2b512;
+static atom_t ATOM_ripemd160;
 
 static atom_t ATOM_pkcs1;
 static atom_t ATOM_pkcs1_oaep;
@@ -231,6 +232,8 @@ hash_options(term_t options, PL_CRYPTO_CONTEXT *result)
         } else if ( a_algorithm == ATOM_blake2s256 )
         { result->algorithm = EVP_blake2s256();
 #endif
+        } else if ( a_algorithm == ATOM_ripemd160 )
+        { result->algorithm = EVP_ripemd160();
         } else
           return PL_domain_error("algorithm", a);
       } else if ( aname == ATOM_hmac )
@@ -1404,6 +1407,7 @@ install_crypto4pl(void)
   MKATOM(md5);
   MKATOM(blake2b512);
   MKATOM(blake2s256);
+  MKATOM(ripemd160);
 
   MKATOM(pkcs1);
   MKATOM(pkcs1_oaep);

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -1322,6 +1322,9 @@ static int
 crypto_lib_init(void)
 {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
+  OpenSSL_add_all_algorithms();
+  ERR_load_crypto_strings();
+
   if ( (old_id_callback=CRYPTO_THREADID_get_callback()) == 0 )
   { int i;
 

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -2707,9 +2707,6 @@ ssl_lib_init(void)
  * One-time library initialization code
  */
 {
-    /* This call will ensure we only end up calling RAND_poll() once
-       - preventing an ugly synchronization issue in OpenSSL */
-    RAND_status();
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     (void) SSL_library_init();
     SSL_load_error_strings();

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -2710,8 +2710,6 @@ ssl_lib_init(void)
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     (void) SSL_library_init();
     SSL_load_error_strings();
-#else
-    (void) OPENSSL_init_ssl(0, NULL);
 #endif
 
     if ((ctx_idx = SSL_CTX_get_ex_new_index( 0


### PR DESCRIPTION
This allows standalone use of `library(crypto)` (i.e., without also using `library(ssl)`) in OpenSSL&lt;1.1.0 for the predicates `evp_encrypt/6` and `evp_decrypt/6`. Other predicates were not affected. This is not particularly important, since OpenSSL&ge;1.1.0 is recommended in any&nbsp;case, but it may help some users.

I have also simplified the initialisation, and removed a dubious workaround of an issue I did not find mentioned anywhere, and which may cause further issues in itself. If there really is a synchronization issue, it is better to bring it fully to&nbsp;light, get to the core of it and then solve it by documented means.