### PR TITLE
ADDED: New predicate ssl_set_options/3 for tweaking SSL contexts

### DIFF
--- a/ssl.doc
+++ b/ssl.doc
@@ -13,7 +13,7 @@
 \begin{document}
 
 \title{SWI-Prolog SSL Interface}
-\author{Markus Triska, Jan van der Steen, Matt Lilley and Jan Wielemaker \\[5pt]
+\author{\href{https://www.metalevel.at}{Markus Triska}, Jan van der Steen, Matt Lilley and Jan Wielemaker \\[5pt]
         E-mail: \email{jan@swi-prolog.org}
        }
 
@@ -357,7 +357,9 @@ custom definitions:
 \end{itemize}
 
 Important use cases of these hooks are running dual-stack RSA/ECDSA
-servers, and updating certificates while the server keeps running.
+servers, updating certificates while the server keeps running, and
+tweaking SSL~parameters for connections. Use ssl_set_options/3 to
+create and configure copies of existing contexts in these hooks.
 
 The example file \file{https.pl} also provides a server that
 \textit{does} require the client to show its certificate. This

--- a/ssl.pl
+++ b/ssl.pl
@@ -45,6 +45,7 @@
             ssl_context/3,                % +Role, -Config, :Options
             ssl_add_certificate_key/4,    % +Config, +Cert, +Key, -Config
             ssl_set_sni_hook/3,           % +Config, +Goal, -Config
+            ssl_set_options/3,            % +Config0, -Config, +Options
             ssl_negotiate/5,              % +Config, +PlainRead, +PlainWrite,
                                           %          -SSLRead,   -SSLWrite
             ssl_peer_certificate/2,       % +Stream, -Certificate
@@ -60,6 +61,7 @@
 
 :- meta_predicate
     ssl_context(+, -, :),
+    ssl_set_options(+, -, :),
     ssl_set_sni_hook(+, 3, -).
 
 :- predicate_options(ssl_context/3, 3,
@@ -316,6 +318,22 @@ ssl_copy_context(SSL0, SSL) :-
 ssl_set_sni_hook(SSL0, Goal, SSL) :-
     ssl_copy_context(SSL0, SSL),
     '_ssl_set_sni_hook'(SSL, Goal).
+
+%!  ssl_set_options(+SSL0, -SSL, +Options)
+%
+%   SSL is the same as SSL0, except for the options specified in
+%   Options.  The following options are supported: close_notify/1,
+%   close_parent/1, host/1, peer_cert/1, ecdh_curve/1,
+%   min_protocol_version/1, max_protocol_version/1,
+%   disable_ssl_methods/1, sni_hook/1, cert_verify_hook/1. See
+%   ssl_context/3 for more information about these options. This
+%   predicate allows you to tweak existing SSL contexts, which can be
+%   useful in hooks when creating servers with the HTTP
+%   infrastructure.
+
+ssl_set_options(SSL0, SSL, Options) :-
+    ssl_copy_context(SSL0, SSL),
+    '_ssl_set_options'(SSL, Options).
 
 %!  ssl_negotiate(+SSL,
 %!                +PlainRead, +PlainWrite,

--- a/ssl.pl
+++ b/ssl.pl
@@ -44,7 +44,6 @@
                                           % +Error
             ssl_context/3,                % +Role, -Config, :Options
             ssl_add_certificate_key/4,    % +Config, +Cert, +Key, -Config
-            ssl_set_sni_hook/3,           % +Config, +Goal, -Config
             ssl_set_options/3,            % +Config0, -Config, +Options
             ssl_negotiate/5,              % +Config, +PlainRead, +PlainWrite,
                                           %          -SSLRead,   -SSLWrite
@@ -61,8 +60,7 @@
 
 :- meta_predicate
     ssl_context(+, -, :),
-    ssl_set_options(+, -, :),
-    ssl_set_sni_hook(+, 3, -).
+    ssl_set_options(+, -, :).
 
 :- predicate_options(ssl_context/3, 3,
                      [ host(atom),
@@ -308,16 +306,6 @@ ssl_add_certificate_key(SSL0, Cert, Key, SSL) :-
 ssl_copy_context(SSL0, SSL) :-
     ssl_context(server, SSL, []),
     '_ssl_init_from_context'(SSL0, SSL).
-
-%!  ssl_set_sni_hook(+SSL0, :Goal, -SSL)
-%
-%   SSL is the same as SSL0, except  that the SNI hook of SSL is Goal.
-%   See  the   sni_hook(:Goal)  option   of  ssl_context/3   for  more
-%   information about this hook.
-
-ssl_set_sni_hook(SSL0, Goal, SSL) :-
-    ssl_copy_context(SSL0, SSL),
-    '_ssl_set_sni_hook'(SSL, Goal).
 
 %!  ssl_set_options(+SSL0, -SSL, +Options)
 %

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -3066,6 +3066,10 @@ parse_malleable_options(PL_SSL *conf, module_t module, term_t options)
                 conf->role == PL_SSL_SERVER )
     { term_t cb = PL_new_term_ref();
       _PL_get_arg(1, head, cb);
+
+      if (conf->cb_sni.goal)
+        PL_erase(conf->cb_sni.goal);
+
       conf->cb_sni.goal   = PL_record(cb);
       conf->cb_sni.module = module;
     } else if ( name == ATOM_close_notify && arity == 1 )
@@ -3504,27 +3508,6 @@ pl_ssl_add_certificate_key(term_t config, term_t cert_arg, term_t key_arg)
   return FALSE;
 }
 
-static foreign_t
-pl_ssl_set_sni_hook(term_t config, term_t t)
-{ PL_SSL *conf;
-  module_t m = NULL;
-  term_t t2 = PL_new_term_ref();
-
-  if ( !get_conf(config, &conf) )
-    return FALSE;
-
-  if ( !PL_strip_module(t, &m, t2) )
-    return FALSE;
-
-  if (conf->cb_sni.goal)
-    PL_erase(conf->cb_sni.goal);
-
-  conf->cb_sni.goal  = PL_record(t2);
-  conf->cb_sni.module = m;
-  ssl_init_sni(conf);
-
-  return TRUE;
-}
 
 static foreign_t
 pl_ssl_debug(term_t level)
@@ -3818,8 +3801,6 @@ install_ssl4pl(void)
   PL_register_foreign("ssl_negotiate",	5, pl_ssl_negotiate,  0);
   PL_register_foreign("_ssl_add_certificate_key",
 					3, pl_ssl_add_certificate_key, 0);
-  PL_register_foreign("_ssl_set_sni_hook",
-					2, pl_ssl_set_sni_hook, 0);
   PL_register_foreign("_ssl_set_options", 2, pl_ssl_set_options, 0);
   PL_register_foreign("ssl_debug",	1, pl_ssl_debug,      0);
   PL_register_foreign("ssl_session",    2, pl_ssl_session,    0);


### PR DESCRIPTION
`ssl_set_options/3` is an important building block for tweaking existing contexts in hooks.

**Note that the existing context is necessary because it may contain certificates and keys that are no longer readable at the time the hook is invoked!**

This new feature finally lets us get rid of `ssl_set_sni_hook/3`, which is currently only necessary in extremely obscure setups and only complicates the SSL&nbsp;interface. The second commit does&nbsp;this.

Please see the respective commit messages for a more detailed description.

Related discussion:

https://github.com/SWI-Prolog/plweb/issues/23

Note that not *all* parameters can currently be tweaked after creation of the context. Notably, it is currently not documented what OpenSSL does if existing certificates are replaced. Related issue:

https://github.com/openssl/openssl/issues/2147

Please see the documentation of the predicate for which options can be currently tweaked.