### PR TITLE
ADDED: library(crypto): HMAC-based key derivation function (HKDF).

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -116,6 +116,8 @@ AC_CHECK_FUNCS(EVP_CIPHER_CTX_reset)
 AC_CHECK_FUNCS(EVP_blake2b512 EVP_blake2s256)
 AC_CHECK_FUNCS(HMAC_CTX_new HMAC_CTX_free)
 
+AC_CHECK_HEADERS(openssl/kdf.h)
+
 if test "x$ac_cv_func_X509_get0_signature" = "xyes"; then
   ac_oldcflags="$CFLAGS"
   CFLAGS="$CFLAGS -Werror"

--- a/crypto.pl
+++ b/crypto.pl
@@ -395,6 +395,8 @@ bytes_base64(Bytes, Base64) :-
 %   single  master key,  using for  example values  such as  =|key|= and
 %   =|iv|=, or the name of a file that is to be encrypted.
 %
+%   This predicate requires OpenSSL 1.1.0 or greater.
+%
 %   @see crypto_n_random_bytes/2 to obtain a suitable salt.
 
 

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -39,7 +39,9 @@
 #include <SWI-Prolog.h>
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
+#ifdef HAVE_OPENSSL_KDF_H
 #include <openssl/kdf.h>
+#endif
 #include "cryptolib.c"
 
 static atom_t ATOM_sslv23;
@@ -633,7 +635,9 @@ pl_crypto_password_hash(term_t tpw, term_t tsalt, term_t titer, term_t tdigest)
 static foreign_t
 pl_crypto_data_hkdf(term_t tkey, term_t tsalt, term_t tinfo, term_t talg,
                     term_t tencoding, term_t toutlen, term_t tout)
-{ EVP_PKEY_CTX *pctx;
+{
+#ifdef HAVE_OPENSSL_KDF_H
+  EVP_PKEY_CTX *pctx;
   char *salt, *key, *info;
   size_t keylen, infolen, outlen, saltlen;
   int rep;
@@ -678,6 +682,9 @@ pl_crypto_data_hkdf(term_t tkey, term_t tsalt, term_t tinfo, term_t talg,
   free(out);
   EVP_PKEY_CTX_free(pctx);
   return raise_ssl_error(ERR_get_error());
+#else
+  return FALSE;
+#endif
 }
 
                  /***************************

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -913,8 +913,7 @@ pl_ecdsa_sign(term_t Private, term_t Data, term_t Enc, term_t Signature)
   EC_KEY *key;
   ECDSA_SIG *sig;
   unsigned char *signature = NULL;
-  unsigned int signature_len;
-  int rc;
+  int signature_len, rc;
 
   if ( !recover_ec(Private, &key) ||
        !get_enc_text(Data, Enc, &data_len, &data) )

--- a/cryptolib.md
+++ b/cryptolib.md
@@ -46,6 +46,18 @@ following specialised predicates are provided:
   * [[crypto_password_hash/2]]
   * [[crypto_password_hash/3]]
 
+### HMAC-based key derivation function (HKDF) {#crypto-hkdf}
+
+The following  predicate implements  the _Hashed  Message Authentication
+Code  (HMAC)-based key  derivation function_,  abbreviated as  HKDF.  It
+supports a wide range of  applications and requirements by concentrating
+possibly  dispersed  entropy  of  the input  keying  material  and  then
+expanding it to the desired length. The number and lengths of the output
+keys depend on the specific  cryptographic algorithms for which the keys
+are needed.
+
+  * [[crypto_data_hkdf/4]]
+
 ### Hashing incrementally {#crypto-hash-incremental}
 
 The   following   predicates   are    provided   for   building   hashes
@@ -178,7 +190,7 @@ Alice in turn performs the following steps:
        of `C` as obtained via crypto_curve_generator/2.
     3. Further, compute the scalar product _j*R_, which is a point on
        the curve that we shall call Q. We can derive a _shared secret_
-       from `Q`, using for example crypto_data_hash/3, and encrypt any
+       from `Q`, using for example crypto_data_hkdf/4, and encrypt any
        message with it (using for example evp_encrypt/6).
     4. Send the point _j*G_ and the encrypted message to Bob.
 


### PR DESCRIPTION
The new predicate crypto_data_hkdf/4 lets you concentrate possibly
dispersed entropy of existing data and then expand it to the desired
length.  This allows you to derive keys and initialization vectors for
cryptographic routines, notably the symmetric encryption predicates.