### PR TITLE
MODIFIED: rsa_sign/4 and rsa_verify/4 now use sha256 by default.

### DIFF
--- a/crypto.pl
+++ b/crypto.pl
@@ -536,7 +536,7 @@ bytes_hex([B|Bs]) -->
 %
 %     - type(+Type)
 %     SHA algorithm used to compute the digest.  Values are
-%     `sha1` (default), `sha224`, `sha256`, `sha384` or `sha512`.
+%     `sha1`, `sha224`, `sha256` (default), `sha384` or `sha512`.
 %
 %     - encoding(+Encoding)
 %     Encoding to use for Data.  Default is `hex`.  Alternatives
@@ -564,7 +564,7 @@ bytes_hex([B|Bs]) -->
 %   directly used in rsa_sign/4 as well as ecdsa_sign/4.
 
 rsa_sign(Key, Data0, Signature, Options) :-
-    option(type(Type), Options, sha1),
+    option(type(Type), Options, sha256),
     option(encoding(Enc0), Options, hex),
     hex_encoding(Enc0, Data0, Enc, Data),
     rsa_sign(Key, Type, Enc, Data, Signature).
@@ -578,14 +578,14 @@ rsa_sign(Key, Data0, Signature, Options) :-
 %
 %     - type(+Type)
 %     SHA algorithm used to compute the digest.  Values are
-%     `sha1` (default), `sha224`, `sha256`, `sha384` or `sha512`.
+%     `sha1`, `sha224`, `sha256` (default), `sha384` or `sha512`.
 %
 %     - encoding(+Encoding)
 %     Encoding to use for Data.  Default is `hex`.  Alternatives
 %     are `octet`, `utf8` and `text`.
 
 rsa_verify(Key, Data0, Signature0, Options) :-
-    option(type(Type), Options, sha1),
+    option(type(Type), Options, sha256),
     option(encoding(Enc0), Options, hex),
     hex_encoding(Enc0, Data0, Enc, Data),
     hex_bytes(Signature0, Signature),

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -1920,7 +1920,7 @@ install_crypto4pl(void)
 
   PL_register_foreign("crypto_n_random_bytes", 2, pl_crypto_n_random_bytes, 0);
 
-  PL_register_foreign("crypto_context_new", 2, pl_crypto_context_new, 0);
+  PL_register_foreign("_crypto_context_new", 2, pl_crypto_context_new, 0);
   PL_register_foreign("_crypto_update_context", 2, pl_crypto_update_context, 0);
   PL_register_foreign("_crypto_context_copy", 2, pl_crypto_context_copy, 0);
   PL_register_foreign("_crypto_context_hash", 2, pl_crypto_context_hash, 0);

--- a/cryptolib.md
+++ b/cryptolib.md
@@ -4,6 +4,49 @@ This library provides bindings  to  functionality   of  OpenSSL  that is
 related to cryptography and authentication,   not  necessarily involving
 connections, sockets or streams.
 
+## Design principle: Secure default algorithms {#crypto-secure-defaults}
+
+A basic design principle of this library is that its _default algorithms
+are  cryptographically secure_  at the  time of  this writing.   We will
+_change_ the default algorithms if an  attack on them becomes known, and
+replace them by new defaults that are deemed appropriate at that time.
+
+This may mean, for example, that where `sha256` is currently the default
+algorithm, `blake2s256` or  some other algorithm may  become the default
+in the future.
+
+To  preserve interoperability  and compatibility  and at  the same  time
+allow us to transparently update default algorithms of this library, the
+following conventions are used:
+
+    1. If an explicit algorithm is specified as an option, then that
+       algorithm is used.
+    2. If _no_ algorithm is specified, then a cryptographically secure
+       algorithm is used.
+    3. If an option that normally specifies an algorithm is present,
+       and a _logical variable_ appears instead of a concrete algorithm,
+       then that variable is unified with the secure default value.
+
+This  allows application  programmers to  inspect _which_  algorithm was
+actually used, and store it for later reference.
+
+For example:
+
+==
+?- crypto_data_hash(test, Hash, [algorithm(A)]).
+Hash = '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
+A = sha256.
+==
+
+This  shows that  at  the  time of  this  writing,  `sha256` was  deemed
+sufficiently secure, and was used as default algorithm for hashing.
+
+You therefore must not rely on  _which_ concrete algorithm is being used
+by  default.  However,  you  can  rely on  the  fact  that  the  default
+algorithms are  secure. In other words,  if they are _not_  secure, then
+this is a mistake in this library,  and we ask you to please report such
+a situation as an urgent security issue.
+
 ## Cryptographically secure random numbers {#crypto-random}
 
 Almost  all  cryptographic  applications  require  the  availability  of


### PR DESCRIPTION
Previously, sha1 was the default. I expect zero impact from this
change, because every programmer who uses these predicates *must*
think about the actual hash algorithm that ought to be used on signing
or verification. It has for several years been known that SHA1 cannot
be considered secure, and in fact even a concrete collision was
recently found. Thus, any existing application must have been migrated
to a different algorithm due to security considerations, making the
old default inapplicable. Also the internal uses of these predicates
all specify the actual algorithm as an option to these predicates, and
hence no further changes were needed anywhere within SWI-Prolog due to
this modification.

The primary purpose of this change is to signal that security is being
taken seriously here, and to do everything that is possible to prevent
future users from relying on insecure algorithms (however unlikely
that may be, since most will explicitly specify a secure algorithm).

The new default of sha256 is also in alignment with what the hash
predicates such as crypto_data_hash/3 produce by default.