### PR TITLE
CLEANUP: "context" --> "hash_context" in internal definitions.

### DIFF
--- a/crypto.pl
+++ b/crypto.pl
@@ -238,8 +238,8 @@ crypto_context_new(Context, Options0) :-
 %   or similar technologies, or simply with big files.
 
 crypto_data_context(Data, Context0, Context) :-
-    '_crypto_context_copy'(Context0, Context),
-    '_crypto_update_context'(Data, Context).
+    '_crypto_hash_context_copy'(Context0, Context),
+    '_crypto_update_hash_context'(Data, Context).
 
 
 %!  crypto_context_hash(+Context, -Hash)
@@ -249,8 +249,8 @@ crypto_data_context(Data, Context0, Context) :-
 %   computation context Context.
 
 crypto_context_hash(Context, Hash) :-
-    '_crypto_context_copy'(Context, Copy),
-    '_crypto_context_hash'(Copy, List),
+    '_crypto_hash_context_copy'(Context, Copy),
+    '_crypto_hash_context_hash'(Copy, List),
     hex_bytes(Hash, List).
 
 %!  crypto_open_hash_stream(+OrgStream, -HashStream, +Options) is det.
@@ -278,7 +278,7 @@ crypto_open_hash_stream(OrgStream, HashStream, Options) :-
 %   the processed input including the already buffered data.
 
 crypto_stream_hash(Stream, Hash) :-
-    '_crypto_stream_context'(Stream, Context),
+    '_crypto_stream_hash_context'(Stream, Context),
     crypto_context_hash(Context, Hash).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
There are different types of "contexts" in OpenSSL. We need to
distinguish hash contexts from cipher contexts in preparation of
incremental encryption, which will become available in SWI 7.8.

The public library(crypto) API is not affected by this change.

There are 3 predicates for incremental hashing:

    crypto_context_new/2
    crypto_data_context/3
    crypto_context_hash/2

There may be slightly better names, and I will reconsider the API of
library(crypto) once incremental encryption is also available.  It
should be rather easy to smoothly transition the hash API because
these predicates are rarely used. crypto_file_hash/3 is more important
for hashes of large files, and that name is perfectly OK.