### PR TITLE
ADDED: Configuration support for TLS 1.3 in min/max_protocol_version.

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -230,14 +230,14 @@ easily be used.
 %     very rarely a concern.
 %     * min_protocol_version(+Atom)
 %     Set the _minimum_ protocol version that can be negotiated.
-%     Atom is one of `sslv3`, `tlsv1`, `tlsv1_1` and `tlsv1_2`.
-%     This option is available with OpenSSL 1.1.0 and later, and
-%     should be used instead of `disable_ssl_methods/1`.
+%     Atom is one of `sslv3`, `tlsv1`, `tlsv1_1`, `tlsv1_2` and
+%     `tlsv1_3`. This option is available with OpenSSL 1.1.0 and
+%     later, and should be used instead of `disable_ssl_methods/1`.
 %     * max_protocol_version(+Atom)
 %     Set the _maximum_ protocol version that can be negotiated.
-%     Atom is one of `sslv3`, `tlsv1`, `tlsv1_1` and `tlsv1_2`.
-%     This option is available with OpenSSL 1.1.0 and later, and
-%     should be used instead of `disable_ssl_methods/1`.
+%     Atom is one of `sslv3`, `tlsv1`, `tlsv1_1`, `tlsv1_2` and
+%     `tlsv1_3`. This option is available with OpenSSL 1.1.0 and
+%     later, and should be used instead of `disable_ssl_methods/1`.
 %     * disable_ssl_methods(+List)
 %     A list of methods to disable. Unsupported methods will be
 %     ignored. Methods include `sslv2`, `sslv3`, `sslv23`,

--- a/ssl.pl
+++ b/ssl.pl
@@ -207,7 +207,7 @@ easily be used.
 %     implementation that accepts any certificate.
 %     * cipher_list(+Atom)
 %     Specify a cipher preference list (one or more cipher strings
-%     separated by colons, commas or spaces).
+%     separated by colons, commas or spaces). See ssl_secure_ciphers/1.
 %     * ecdh_curve(+Atom)
 %     Specify a curve for ECDHE ciphers. If this option is not
 %     specified, the OpenSSL default parameters are used.  With
@@ -496,11 +496,14 @@ cert_accept_any(_SSL,
 
 %!  ssl_secure_ciphers(-Ciphers:atom) is det.
 %
+%   Ciphers is a  secure cipher preference list that can  be used in the
+%   cipher_list/1 option of ssl_context/3.
+%
 %   Secure ciphers must guarantee forward secrecy, and must mitigate all
-%   known critical attacks. As of  2017,   using  the  following ciphers
-%   allows you to obtain grade A on https://www.ssllabs.com. For A+, you
-%   must also enable HTTP Strict Transport  Security (HSTS) by sending a
-%   suitable header field in replies.
+%   known critical attacks.  As of  2018, using these ciphers allows you
+%   to obtain grade A on  https://www.ssllabs.com. For A+, you must also
+%   enable HTTP Strict  Transport Security (HSTS) by  sending a suitable
+%   header field in replies.
 %
 %   Note that obsolete ciphers *must* be   disabled  to reliably prevent
 %   protocol downgrade attacks.

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -4,7 +4,7 @@
 		   and Markus Triska
     E-mail:        J.Wielemaker@vu.nl
     WWW:           http://www.swi-prolog.org
-    Copyright (c)  2004-2017, SWI-Prolog Foundation
+    Copyright (c)  2004-2018, SWI-Prolog Foundation
                               VU University Amsterdam
     All rights reserved.
 
@@ -103,6 +103,7 @@ static atom_t ATOM_sslv3;
 static atom_t ATOM_tlsv1;
 static atom_t ATOM_tlsv1_1;
 static atom_t ATOM_tlsv1_2;
+static atom_t ATOM_tlsv1_3;
 static atom_t ATOM_minus;			/* "-" */
 
 static functor_t FUNCTOR_unsupported_hash_algorithm1;
@@ -2816,6 +2817,10 @@ protocol_version_to_integer(const term_t symbol, int *version)
     *version = TLS1_1_VERSION;
   else if ( arg == ATOM_tlsv1_2 )
     *version = TLS1_2_VERSION;
+#ifdef TLS1_3_VERSION
+  else if ( arg == ATOM_tlsv1_3 )
+    *version = TLS1_3_VERSION;
+#endif
   else
     return PL_domain_error("ssl_protocol_version", symbol);
 #else
@@ -3658,6 +3663,7 @@ install_ssl4pl(void)
   MKATOM(tlsv1);
   MKATOM(tlsv1_1);
   MKATOM(tlsv1_2);
+  MKATOM(tlsv1_3);
   MKATOM(require_crl);
   MKATOM(crl);
 


### PR DESCRIPTION
TLS 1.3 is available with OpenSSL 1.1.1 or later.