### PR TITLE
ENHANCED: Always set close_parent(true) in HTTP server hooks.

### DIFF
--- a/http_ssl_plugin.pl
+++ b/http_ssl_plugin.pl
@@ -3,7 +3,7 @@
     Author:        Jan Wielemaker
     E-mail:        J.Wielemaker@vu.nl
     WWW:           http://www.swi-prolog.org
-    Copyright (c)  2007-2016, University of Amsterdam
+    Copyright (c)  2007-2018, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.
 
@@ -81,11 +81,7 @@ thread_httpd:make_socket_hook(Port, M:Options0, Options) :-
     add_secure_ciphers(SSLOptions0, SSLOptions1),
     disable_sslv3(SSLOptions1, SSLOptions),
     make_socket(Port, Socket, Options1),
-    ssl_context(server,
-                SSL0,
-                M:[ close_parent(true)
-                  | SSLOptions
-                  ]),
+    ssl_context(server, SSL0, M:SSLOptions),
     (   http:ssl_server_create_hook(SSL0, SSL, Options1)
     ->  true
     ;   SSL = SSL0
@@ -176,14 +172,15 @@ thread_httpd:open_client_hook(ssl_client(SSL0, Client, Goal, Peer),
                               Goal, In, Out,
                               [peer(Peer), protocol(https)],
                               Options) :-
-    (   http:ssl_server_open_client_hook(SSL0, SSL, Options)
+    (   http:ssl_server_open_client_hook(SSL0, SSL1, Options)
     ->  true
-    ;   SSL = SSL0
+    ;   SSL1 = SSL0
     ),
     option(timeout(TMO), Options, 60),
     tcp_open_socket(Client, Read, Write),
     set_stream(Read, timeout(TMO)),
     set_stream(Write, timeout(TMO)),
+    ssl_set_options(SSL1, SSL, [close_parent(true)]),
     catch(ssl_negotiate(SSL, Read, Write, In, Out),
           E,
           ssl_failed(Read, Write, E)).


### PR DESCRIPTION
This ensures that HTTP timeouts are properly propagated.

Example:

    :- use_module(library(http/thread_httpd)).
    :- use_module(library(http/http_dispatch)).
    :- use_module(library(http/http_unix_daemon)).

    :- http_handler(/, handle_request, []).

    handle_request(_Request) :-
        format("Content-type: text/plain~n~n"),
        format("Hello!").

    http:ssl_server_open_client_hook(_SSL0, SSL, _Options) :-
            ssl_context(server, SSL,
                        [certificate_file('etc/server/server-cert.pem'),
                         key_file('etc/server/server-key.pem'),
                         password(apenoot1)]).

Put this code in http_server.pl and launch the server with:

    $ p=etc/server; swipl https_server.pl --https \
                       --interactive --port=4090  --timeout=0.1

Then connect with:

    $ openssl s_client -connect localhost:4090

It should terminate almost instantly.