### PR TITLE
FIXED: build test certificates only if not crosscompiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,8 @@ add_compile_options(-D__SWI_PROLOG__
 		    -DSERVER_CERT_REQUIRED=TRUE
 		    -DCLIENT_CERT_REQUIRED=TRUE)
 
-if(SSL_TESTS)
+# We want to do SSL tests directly on the target platform
+if(SSL_TESTS AND NOT CMAKE_CROSSCOMPILING)
   add_custom_command(
       OUTPUT  tests/test_certs/generated
       COMMAND ${CMAKE_COMMAND} -E make_directory tests


### PR DESCRIPTION
For the Android port, we do two compiling passes:
1. _Native build_: to produce proper binaries to be used during the build (32-bit or 64-bit)
2. _Android build_: Crosscompile to the android target.

This patch avoids the generation of ssl test certificates during (1) --the native build-- since the SSL tests will be done in the target platform.
Please see SWI-Prolog/swipl-devel#358