### PR TITLE
fixes warning about OPENSSL_zalloc defined but never used

### DIFF
--- a/cryptolib.c
+++ b/cryptolib.c
@@ -37,7 +37,8 @@
 
 #include "cryptolib.h"
 
-#if !defined(HAVE_OPENSSL_ZALLOC) && !defined(OPENSSL_zalloc)
+/* OPENSSL_zalloc is only used in the EVP_MD_CTX_new defined below */
+#if !defined(HAVE_OPENSSL_ZALLOC) && !defined(OPENSSL_zalloc) && !defined(HAVE_EVP_MD_CTX_FREE)
 static void *
 OPENSSL_zalloc(size_t num)
 { void *ret = OPENSSL_malloc(num);


### PR DESCRIPTION
LibreSSL has got EVP_MD_CTX_(free|new) but not OPENSSL_zalloc, the
compiler complains about the last being defined but never used.

As OPENSSL_zalloc is only used in the EVP_MD_CTX_new, it is only
defined iff the EVP_MD_CTX_(new|free) pair is defined.