### PR TITLE
First attempt at processing raw certificates. Adds support for writin…

### DIFF
--- a/ssl.doc
+++ b/ssl.doc
@@ -427,6 +427,25 @@ Virtual hosts for HTTPS are available via \jargon{Server Name
 host different domains from the same IP address. See the sni_hook/1
 option of ssl_context/3 for more information.
 
+\section{Compatibility of the API}
+\label{sec:compatibility}
+Previous versions of the library used plain Prolog terms to represent
+the certificate objects as lists of fields. Newer versions of the
+library preserve the raw underlying structures as opaque handles to
+allow for more complicated operations to be performed on them. Any old
+code which obtains fields from the certificate using memberchk/2
+should be modified to use certificate_field/2 instead. For example,
+\begin{code}
+  memberchk(subject(Subject), Certificate)
+\end{code}
+will instead need to be
+\begin{code}
+  cerficate_field(Certificate, subject(Subject))
+\end{code}
+
+Note that some of the fields do not match up exactly with their
+previous counterparts (key is now public_key, for example).
+
 \section{Acknowledgments}
 \label{sec:ssl-acknowledgments}
 

--- a/ssl.pl
+++ b/ssl.pl
@@ -34,7 +34,7 @@
 */
 
 :- module(ssl,
-	  [ certificate_property/2,       % +Certificate, ?Property
+	  [ certificate_field/2,          % +Certificate, ?Field
 	    load_certificate/2,           % +Stream, -Certificate
 	    load_private_key/3,           % +Stream, +Password, -Key
             load_public_key/2,            % +Stream, -Key
@@ -420,7 +420,7 @@ ssl_set_options(SSL0, SSL, Options) :-
 %
 %   Loads a certificate from a PEM- or DER-encoded stream, returning
 %   a certificate. The fields of the certificate can be inspected
-%   using certificate_property(+Certificate, ?Property).
+%   using certificate_field(+Certificate, ?Field).
 %
 %   Note that the OpenSSL `CA.pl`  utility creates certificates that
 %   have a human readable textual representation in front of the PEM
@@ -528,10 +528,10 @@ ssl_set_options(SSL0, SSL, Options) :-
 %   To use the system built-in trust store, specify the special term
 %   system(root_certificates) for TrustedCertificates.
 
-%!  certificate_property(+Certificate,
-%!			 ?Property) is nondet.
+%!  certificate_field(+Certificate,
+%!		      ?Field) is nondet.
 %
-%   Retrieve the property matching Property from Certificate. May be
+%   Retrieve the field matching Field from Certificate. May be
 %   one of the following:
 %     * subject/1 to retrieve the subject
 %     * issuer/1  to retrieve the issuer's subject

--- a/ssl.pl
+++ b/ssl.pl
@@ -208,7 +208,7 @@ easily be used.
 %     certifications from the `cacert_file` option, Error is unified
 %     with the atom `verified`. Otherwise it contains the error
 %     string passed from OpenSSL. Access will be granted iff the
-%     predicate succeeds. See load_certificate/3 for a description
+%     predicate succeeds. See load_certificate/2 for a description
 %     of the certificate terms. See cert_accept_any/5 for a dummy
 %     implementation that accepts any certificate.
 %     * cipher_list(+Atom)

--- a/ssl.pl
+++ b/ssl.pl
@@ -34,10 +34,9 @@
 */
 
 :- module(ssl,
-	  [ certificate_property/2,       % +RawCertificate, ?Property
+	  [ certificate_property/2,       % +Certificate, ?Property
 	    load_certificate/2,           % +Stream, -Certificate
-	    load_certificate/3,           % +Stream, -Certificate, +Format
-            load_private_key/3,           % +Stream, +Password, -Key
+	    load_private_key/3,           % +Stream, +Password, -Key
             load_public_key/2,            % +Stream, -Key
 	    load_crl/2,                   % +Stream, -Crl
 	    write_certificate/3,          % +Stream, -X509, +Options
@@ -55,7 +54,7 @@
             ssl_session/2,                % +Stream, -Session
 	    ssl_secure_ciphers/1,         % -Ciphers,
 	    verify_certificate/3,         % +X509, +AuxiliaryCertificates, +TrustedCertificates
-	    verify_certificate_issuer/2   % +RawCertificate, +RawIssuerCertificate
+	    verify_certificate_issuer/2   % +Certificate, +IssuerCertificate
           ]).
 :- use_module(library(option)).
 :- use_module(library(settings)).
@@ -417,23 +416,11 @@ ssl_set_options(SSL0, SSL, Options) :-
 %     The negotiated ALPN protocol, if supported. If no protocol was
 %     negotiated, this will be an empty string.
 
-load_certificate(Stream, Certificate):-
-	load_certificate(Stream, Certificate, prolog).
-
-%!  load_certificate(+Stream, -Certificate, +Format) is det.
+%!  load_certificate(+Stream, -Certificate) is det.
 %
 %   Loads a certificate from a PEM- or DER-encoded stream, returning
-%   a certificate in either a prolog-style representation or a
-%   native representation, depending on Format (which can be *raw*
-%   or *prolog*. If raw, predicates certificate_*/2 below can be used
-%   to extract the certificate fields. If prolog, then the term will
-%   contain the following terms: issuer_name/1, hash/1, signature/1,
-%   signature_algorithm/1,   version/1,   notbefore/1,   notafter/1,
-%   serial/1, subject/1 and key/1.   subject/1 and issuer_name/1 are
-%   both lists  of =/2  terms representing  the name.   With OpenSSL
-%   1.0.2 and  greater, to_be_signed/1  is also  available, yielding
-%   the hexadecimal representation of the TBS (to-be-signed) portion
-%   of the certificate.
+%   a certificate. The fields of the certificate can be inspected
+%   using certificate_property(+Certificate, ?Property).
 %
 %   Note that the OpenSSL `CA.pl`  utility creates certificates that
 %   have a human readable textual representation in front of the PEM
@@ -452,8 +439,8 @@ load_certificate(Stream, Certificate):-
 
 %!  write_certificate(+Stream, +Certificate, +Options) is det.
 %
-%   Writes a (raw) certificate to the stream Stream. Options is
-%   reserved for future use.
+%   Writes a certificate to the stream Stream. Options is reserved
+%   for future use.
 
 %!  load_crl(+Stream, -CRL) is det.
 %
@@ -527,8 +514,8 @@ load_certificate(Stream, Certificate):-
 %!  verify_certificate_issuer(+Certificate,
 %!			      +Issuer).
 %
-%   True if Certificate is a (raw) certificate which was issued by the
-%   (raw) certificate Issuer.
+%   True if Certificate is a certificate which was issued by the
+%   certificate Issuer.
 
 %!  verify_certificate(+Certificate,
 %!		       +AuxiliaryCertificates,
@@ -540,7 +527,6 @@ load_certificate(Stream, Certificate):-
 %   chain.
 %   To use the system built-in trust store, specify the special term
 %   system(root_certificates) for TrustedCertificates.
-%   Note that all the certificates supplied must be in *raw* format.
 
 %!  certificate_property(+Certificate,
 %!			 ?Property) is nondet.
@@ -556,6 +542,11 @@ load_certificate(Stream, Certificate):-
 %     * public_key/1 to retrieve the public key
 %     * crls/1 to retrieve a list of the CRLs
 %     * sans/1 to retrieve a list of the Subject Alternative Names
+%     * signature/1 to retrieve the certificate signature
+%     * signature_algorithm/1 to retrieve the signing algorithm
+%     * hash/1 to retrieve the certificate hash
+%     * to_be_signed/1 to retrieve the data on the certificate which
+%        must be signed
 
 
 

--- a/ssl.pl
+++ b/ssl.pl
@@ -34,7 +34,7 @@
 */
 
 :- module(ssl,
-	  [ certificate_field/2,          % +RawCertificate, ?Field
+	  [ certificate_property/2,       % +RawCertificate, ?Property
 	    load_certificate/2,           % +Stream, -Certificate
 	    load_certificate/3,           % +Stream, -Certificate, +Format
             load_private_key/3,           % +Stream, +Password, -Key
@@ -542,10 +542,10 @@ load_certificate(Stream, Certificate):-
 %   system(root_certificates) for TrustedCertificates.
 %   Note that all the certificates supplied must be in *raw* format.
 
-%!  certificate_field(+Certificate,
-%!		      ?Field) is nondet.
+%!  certificate_property(+Certificate,
+%!			 ?Property) is nondet.
 %
-%   Retrieve the field matching Field from Certificate. Field may be
+%   Retrieve the property matching Property from Certificate. May be
 %   one of the following:
 %     * subject/1 to retrieve the subject
 %     * issuer/1  to retrieve the issuer's subject

--- a/ssl.pl
+++ b/ssl.pl
@@ -34,15 +34,7 @@
 */
 
 :- module(ssl,
-	  [ certificate_crls/2,           % +RawCertificate, -CRLS
-	    certificate_issuer/2,         % +RawCertificate, -Issuer
-	    certificate_not_after/2,      % +RawCertificate, -NotAfter
-	    certificate_not_before/2,     % +RawCertificate, -NotBefore
-	    certificate_public_key/2,     % +RawCertificate, -PublicKey
-	    certificate_san/2,            % +RawCertificate, -SAN
-	    certificate_serial/2,         % +RawCertificate, -Serial
-	    certificate_subject/2,        % +RawCertificate, -Subject
-	    certificate_version/2,        % +RawCertificate, -Version
+	  [ certificate_field/2,          % +RawCertificate, ?Field
 	    load_certificate/2,           % +Stream, -Certificate
 	    load_certificate/3,           % +Stream, -Certificate, +Format
             load_private_key/3,           % +Stream, +Password, -Key
@@ -550,51 +542,21 @@ load_certificate(Stream, Certificate):-
 %   system(root_certificates) for TrustedCertificates.
 %   Note that all the certificates supplied must be in *raw* format.
 
-%!  certificate_crls(+Certificate,
-%!		     -CRLs).
+%!  certificate_field(+Certificate,
+%!		      ?Field) is nondet.
 %
-%   Retrieve the CRL fields (if any) from the (raw) certificate Certificate
+%   Retrieve the field matching Field from Certificate. Field may be
+%   one of the following:
+%     * subject/1 to retrieve the subject
+%     * issuer/1  to retrieve the issuer's subject
+%     * version/1  to retrieve the version
+%     * serial/1  to retrieve the serial number
+%     * not_before/1 to retrieve the start date
+%     * not_after/1  to retrieve the expiry date
+%     * public_key/1 to retrieve the public key
+%     * crls/1 to retrieve a list of the CRLs
+%     * sans/1 to retrieve a list of the Subject Alternative Names
 
-%!  certificate_issuer(+Certificate,
-%!		       -Issuer).
-%
-%   Retrieve the issuer name from the (raw) certificate Certificate
-
-%!  certificate_not_after(+Certificate,
-%!			  -NotAfter).
-%
-%   Retrieve the expiry date from the (raw) certificate Certificate
-
-%!  certificate_not_before(+Certificate,
-%!			  -NotBefore).
-%
-%   Retrieve the start date from the (raw) certificate Certificate
-
-%!  certificate_public_key(+Certificate,
-%!			   -PublicKey).
-%
-%   Retrieve the public key from the (raw) certificate Certificate
-
-%!  certificate_san(+Certificate,
-%!		    -SANList).
-%
-%   Retrieve the subject alt names (if any) from the (raw) certificate
-%   Certificate
-
-%!  certificate_serial(+Certificate,
-%!		       -Serial).
-%
-%   Retrieve the serial number from the (raw) certificate Certificate
-
-%!  certificate_subject(+Certificate,
-%!			-Subject).
-%
-%   Retrieve the subject from the (raw) certificate Certificate
-
-%!  certificate_version(+Certificate,
-%!			-Version).
-%
-%   Retrieve the version from the (raw) certificate Certificate
 
 
 cert_accept_any(_SSL,

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -1036,27 +1036,27 @@ typedef struct
    int index;
    int deterministic;
    X509* cert;
-   term_t current_property;
-} prop_enum;
+   term_t current_field;
+} field_enum;
 
 static foreign_t
-fetch_subject(term_t Property, X509* cert)
-{ return unify_name(Property, X509_get_subject_name(cert));
+fetch_subject(term_t Field, X509* cert)
+{ return unify_name(Field, X509_get_subject_name(cert));
 }
 
 static foreign_t
-fetch_issuer(term_t Property, X509* cert)
-{ return unify_name(Property, X509_get_issuer_name(cert));
+fetch_issuer(term_t Field, X509* cert)
+{ return unify_name(Field, X509_get_issuer_name(cert));
 }
 
 
 static foreign_t
-fetch_version(term_t Property, X509* cert)
-{ return PL_unify_integer(Property, X509_get_version(cert));
+fetch_version(term_t Field, X509* cert)
+{ return PL_unify_integer(Field, X509_get_version(cert));
 }
 
 static foreign_t
-fetch_serial(term_t Property, X509* cert)
+fetch_serial(term_t Field, X509* cert)
 { BIO * mem = NULL;
   long n;
   int rc = 0;
@@ -1065,7 +1065,7 @@ fetch_serial(term_t Property, X509* cert)
   if ((mem = BIO_new(BIO_s_mem())) != NULL)
   { i2a_ASN1_INTEGER(mem, X509_get_serialNumber(cert));
     if ((n = BIO_get_mem_data(mem, &p)) > 0)
-      rc = PL_unify_atom_nchars(Property, (size_t)n, (char*)p);
+      rc = PL_unify_atom_nchars(Field, (size_t)n, (char*)p);
     BIO_vfree(mem);
     return rc;
   }
@@ -1074,28 +1074,28 @@ fetch_serial(term_t Property, X509* cert)
 
 
 static foreign_t
-fetch_not_before(term_t Property, X509* cert)
-{ return unify_asn1_time(Property, X509_get0_notBefore(cert));
+fetch_not_before(term_t Field, X509* cert)
+{ return unify_asn1_time(Field, X509_get0_notBefore(cert));
 }
 
 static foreign_t
-fetch_not_after(term_t Property, X509* cert)
-{ return unify_asn1_time(Property, X509_get0_notAfter(cert));
+fetch_not_after(term_t Field, X509* cert)
+{ return unify_asn1_time(Field, X509_get0_notAfter(cert));
 }
 
 
 static foreign_t
-fetch_public_key(term_t Property, X509* cert)
+fetch_public_key(term_t Field, X509* cert)
 { EVP_PKEY *key;
   int rc;
   key = X509_get_pubkey(cert);
-  rc = unify_public_key(key, Property);
+  rc = unify_public_key(key, Field);
   EVP_PKEY_free(key);
   return rc;
 }
 
 static foreign_t
-fetch_crls(term_t Property, X509* cert)
+fetch_crls(term_t Field, X509* cert)
 { unsigned int crl_ext_id;
   X509_EXTENSION * crl_ext = NULL;
 
@@ -1134,16 +1134,16 @@ fetch_crls(term_t Property, X509* cert)
       }
     }
     CRL_DIST_POINTS_free(distpoints);
-    return PL_unify_nil(crl_list) && PL_unify(Property, crl);
+    return PL_unify_nil(crl_list) && PL_unify(Field, crl);
   }
   else
   { /* No CRL */
-    return PL_unify_nil(Property);
+    return PL_unify_nil(Field);
   }
 }
 
 static foreign_t
-fetch_sans(term_t Property, X509* cert)
+fetch_sans(term_t Field, X509* cert)
 { unsigned int san_ext_id;
   X509_EXTENSION * san_ext = NULL;
 
@@ -1171,46 +1171,46 @@ fetch_sans(term_t Property, X509* cert)
       }
     }
     sk_GENERAL_NAME_pop_free(san_names, GENERAL_NAME_free);
-    return PL_unify_nil(san_list) && PL_unify(Property, san);
+    return PL_unify_nil(san_list) && PL_unify(Field, san);
   }
   else
   { /* No SAN */
-    return PL_unify_nil(Property);
+    return PL_unify_nil(Field);
   }
 }
 
 static foreign_t
-fetch_signature(term_t Property, X509* cert)
+fetch_signature(term_t Field, X509* cert)
 { GET0SIG_CONST_T ASN1_BIT_STRING *psig;
   GET0SIG_CONST_T X509_ALGOR *palg;
   X509_get0_signature(&psig, &palg, cert);
-  return unify_bytes_hex(Property, psig->length, psig->data);
+  return unify_bytes_hex(Field, psig->length, psig->data);
 }
 
 
 static foreign_t
-fetch_signature_algorithm(term_t Property, X509* cert)
+fetch_signature_algorithm(term_t Field, X509* cert)
 { GET0SIG_CONST_T ASN1_BIT_STRING *psig;
   GET0SIG_CONST_T X509_ALGOR *palg;
   const char *salgorithm;
   
   X509_get0_signature(&psig, &palg, cert);
   if ((salgorithm = OBJ_nid2sn(OBJ_obj2nid(palg->algorithm))) != NULL)
-  { return PL_unify_chars(Property, PL_ATOM|REP_UTF8, strlen(salgorithm), salgorithm);
+  { return PL_unify_chars(Field, PL_ATOM|REP_UTF8, strlen(salgorithm), salgorithm);
   }
   return FALSE;
 }
 
 static foreign_t
-fetch_hash(term_t Property, X509* cert)
+fetch_hash(term_t Field, X509* cert)
 { GET0SIG_CONST_T ASN1_BIT_STRING *psig;
   GET0SIG_CONST_T X509_ALGOR *palg;
   
   X509_get0_signature(&psig, &palg, cert);
 #ifdef HAVE_X509_DIGEST
-  return unify_hash(Property, palg->algorithm, hash_X509_digest_wrapper, cert);
+  return unify_hash(Field, palg->algorithm, hash_X509_digest_wrapper, cert);
 #else
-  return unify_hash(Property, palg->algorithm, i2d_X509_CINF_wrapper, cert->cert_info);
+  return unify_hash(Field, palg->algorithm, i2d_X509_CINF_wrapper, cert->cert_info);
 #endif
 }
 
@@ -1218,12 +1218,12 @@ fetch_hash(term_t Property, X509* cert)
 
 #ifdef HAVE_I2D_RE_X509_TBS
 static foreign_t
-fetch_to_be_signed(term_t Property, X509* cert)
+fetch_to_be_signed(term_t Field, X509* cert)
 { unsigned char *tbs = NULL;
   int tbs_len = i2d_re_X509_tbs(cert, &tbs);
   int rc = 0;
   if (tbs_len >= 0)
-    rc = unify_bytes_hex(Property, tbs_len, tbs);
+    rc = unify_bytes_hex(Field, tbs_len, tbs);
   OPENSSL_free(tbs);
   return rc;
 }
@@ -1234,7 +1234,7 @@ struct
 {
   const char* name;
   foreign_t (*fetch)(term_t, X509*);
-} certificate_properties[] = {{"subject", fetch_subject},
+} certificate_fields[] = {{"subject", fetch_subject},
 			      {"issuer", fetch_issuer},
 			      {"not_before", fetch_not_before},
 			      {"not_after", fetch_not_after},
@@ -1252,58 +1252,58 @@ struct
 			      {NULL, NULL}};
 
 
-static int fetch_property(prop_enum *state)
-{ if (certificate_properties[state->index].name != 0)
+static int fetch_field(field_enum *state)
+{ if (certificate_fields[state->index].name != 0)
   { term_t arg = PL_new_term_ref();
-    int rc = certificate_properties[state->index].fetch(arg, state->cert);
-    state->current_property = PL_new_term_ref();
-    return rc && PL_unify_term(state->current_property,
-			       PL_FUNCTOR_CHARS, certificate_properties[state->index].name, 1,
+    int rc = certificate_fields[state->index].fetch(arg, state->cert);
+    state->current_field = PL_new_term_ref();
+    return rc && PL_unify_term(state->current_field,
+			       PL_FUNCTOR_CHARS, certificate_fields[state->index].name, 1,
 			       PL_TERM, arg);
   }
   return 0;
 }
 
 static
-foreign_t pl_certificate_property(term_t Certificate, term_t Property, control_t handle)
-{ prop_enum *state;
+foreign_t pl_certificate_field(term_t Certificate, term_t Field, control_t handle)
+{ field_enum *state;
   switch(PL_foreign_control(handle))
   { case PL_FIRST_CALL:
-    state = PL_malloc(sizeof(prop_enum));
-    memset(state, 0, sizeof(prop_enum));
+    state = PL_malloc(sizeof(field_enum));
+    memset(state, 0, sizeof(field_enum));
     if ( !get_certificate_blob(Certificate, &state->cert) )
     { PL_free(state);
       return FALSE;
     }
-    if (!PL_is_variable(Property)) /* deterministic case */
+    if (!PL_is_variable(Field)) /* deterministic case */
     { atom_t name;
       size_t arity;
       const char* namec;
-      if (!PL_get_name_arity(Property, &name, &arity) || arity != 1)
+      if (!PL_get_name_arity(Field, &name, &arity) || arity != 1)
       { PL_free(state);
-	return PL_type_error("property", Property);
+	return PL_type_error("field", Field);
       }
       namec = PL_atom_chars(name);
-      while (certificate_properties[state->index].name != NULL)
-      { if (strcmp(certificate_properties[state->index].name, namec) == 0)
+      while (certificate_fields[state->index].name != NULL)
+      { if (strcmp(certificate_fields[state->index].name, namec) == 0)
 	{ state->deterministic = 1;
 	  break;
 	}
 	state->index++;
       }
-      if (certificate_properties[state->index].name == 0)
+      if (certificate_fields[state->index].name == 0)
       { PL_free(state);
-	return PL_existence_error("property", Property);
+	return PL_existence_error("field", Field);
       }
     }
-    if (!fetch_property(state))
+    if (!fetch_field(state))
     { PL_free(state);
       PL_fail;
     }
     break;
   case PL_REDO:
      state = PL_foreign_context_address(handle);
-     if (!fetch_property(state))
+     if (!fetch_field(state))
      { PL_free(state);
        PL_fail;
      }
@@ -1316,7 +1316,7 @@ foreign_t pl_certificate_property(term_t Certificate, term_t Property, control_t
   default:
     return FALSE;
   }
-  if (PL_unify(Property, state->current_property))
+  if (PL_unify(Field, state->current_field))
   { if (state->deterministic)
     { PL_free(state);
       PL_succeed;
@@ -4178,7 +4178,7 @@ install_ssl4pl(void)
   PL_register_foreign("load_public_key", 2,pl_load_public_key,      0);
   PL_register_foreign("system_root_certificates", 1, pl_system_root_certificates, 0);
 
-  PL_register_foreign("certificate_property", 2, pl_certificate_property, PL_FA_NONDETERMINISTIC);
+  PL_register_foreign("certificate_field", 2, pl_certificate_field, PL_FA_NONDETERMINISTIC);
   PL_register_foreign("verify_certificate_issuer", 2, pl_verify_certificate_issuer, 0);
 
 /* Note that libcrypto threading needs to be initialized exactly once.

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -827,7 +827,7 @@ write_cert(IOSTREAM *s, atom_t symbol, int flags)
 
 static PL_blob_t certificate_type =
 { PL_BLOB_MAGIC,
-  PL_BLOB_NOCOPY,
+  PL_BLOB_UNIQUE | PL_BLOB_NOCOPY,
   "ssl_certificate",
   release_cert,
   NULL,

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -813,14 +813,14 @@ unify_private_key(EVP_PKEY* key, term_t item)
 
 static int
 release_cert(atom_t atom)
-{ X509 **cert = PL_blob_data(atom, NULL, NULL);
-  X509_free(*cert);
+{ X509 *cert = PL_blob_data(atom, NULL, NULL);
+  X509_free(cert);
   return TRUE;
 }
 
 static int
 write_cert(IOSTREAM *s, atom_t symbol, int flags)
-{ X509 **cert = PL_blob_data(symbol, NULL, NULL);
+{ X509 *cert = PL_blob_data(symbol, NULL, NULL);
   Sfprintf(s, "<ssl_certificate>(%p)", cert);
   return TRUE;
 }

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -2249,7 +2249,7 @@ ssl_cb_cert_verify(int preverify_ok, X509_STORE_CTX *ctx)
           case X509_V_ERR_CERT_HAS_EXPIRED:
             error = "expired";
             break;
-	  case X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD:
+          case X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD:
           case X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD:
           case X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD:
           case X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD:

--- a/test_ssl.pl
+++ b/test_ssl.pl
@@ -147,7 +147,7 @@ test(trip_private_public, In == Out) :-
               ( skip_to_pem_cert(S2),
                 load_certificate(S2, Cert)
               )),
-    memberchk(key(PublicKey), Cert),
+    certificate_field(Cert, public_key(PublicKey)),
     rsa_private_encrypt(PrivateKey, In, Encrypted, []),
     rsa_public_decrypt(PublicKey, Encrypted, Out, []).
 test(trip_private_public, In == Out) :-
@@ -159,7 +159,7 @@ test(trip_private_public, In == Out) :-
               ( skip_to_pem_cert(S2),
                 load_certificate(S2, Cert)
               )),
-    memberchk(key(PublicKey), Cert),
+    certificate_field(Cert, public_key(PublicKey)),
     rsa_private_encrypt(PrivateKey, In, Encrypted, []),
     rsa_public_decrypt(PublicKey, Encrypted, Out, []).
 test(trip_public_private, In == Out) :-
@@ -170,7 +170,7 @@ test(trip_public_private, In == Out) :-
               ( skip_to_pem_cert(S2),
                 load_certificate(S2, Cert)
               )),
-    memberchk(key(PublicKey), Cert),
+    certificate_field(Cert, public_key(PublicKey)),
     rsa_public_encrypt(PublicKey, In, Encrypted, []),
     rsa_private_decrypt(PrivateKey, Encrypted, Out, []).
 
@@ -572,7 +572,7 @@ test_crl_hook(_SSL, Cert, _Chain, _Tail, revoked):-
     setup_call_cleanup(open('tests/test_certs/rootCA-crl.pem', read, Stream),
                        load_crl(Stream, CRL),
                        close(Stream)),
-    memberchk(serial(Serial), Cert),
+    certificate_field(Cert, serial(Serial)),
     memberchk(revocations(Revocations), CRL),
     \+memberchk(revoked(Serial, _RevocationTime), Revocations).
 
@@ -714,15 +714,15 @@ test(roundtrip, RecoveredText == Text) :-
                  *******************************/
 
 is_certificate(Cert) :-
-    is_list(Cert),
-    memberchk(version(V), Cert), integer(V),
-    memberchk(notbefore(NB), Cert), integer(NB),
-    memberchk(notafter(NA), Cert), integer(NA),
-    memberchk(subject(Subj), Cert), is_subject(Subj),
-    memberchk(hash(H), Cert), is_hex_string(H),
-    memberchk(signature(S), Cert), is_hex_string(S),
-    memberchk(issuer_name(Issuer), Cert), is_issuer(Issuer),
-    memberchk(key(K), Cert), is_public_key(K).
+    blob(Cert, ssl_certificate),
+    certificate_field(Cert, version(V)), integer(V),
+    certificate_field(Cert, not_before(NB)), integer(NB),
+    certificate_field(Cert, not_after(NA)), integer(NA),
+    certificate_field(Cert, subject(Subj)), is_subject(Subj),
+    certificate_field(Cert, hash(H)), is_hex_string(H),
+    certificate_field(Cert, signature(S)), is_hex_string(S),
+    certificate_field(Cert, issuer(Issuer)), is_issuer(Issuer),
+    certificate_field(Cert, public_key(K)), is_public_key(K).
 
 is_subject(Subj) :-
     is_list(Subj),


### PR DESCRIPTION
…g certificates, verifying certificate chains and verifying the issuer of a certificate

This probably needs some discussion still.

I'm still not sure about this dual representation idea; there are some predicates which take certificates in one format, some which take it in the other, and some which only produce prolog-style terms (like the system root ones and the cert callbacks). I think it might be better just to switch to everything using blobs and provide something like
	certificate_fields(+Blob, -PrologTerm)
To make backward compatibility relatively straightforward for existing users. 
