### PR TITLE
Add cacerts/1 option to allow specifying trusted certificates from pl…

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -190,6 +190,10 @@ easily be used.
 %     the FileName `system(root_certificates)` uses a list of
 %     trusted root certificates as provided by the OS. See
 %     system_root_certificates/1 for details.
+%     * cacerts(+ListOfCertificates)
+%     Specify a list of certificates of _trusted_ certificates.
+%     This is equivalent to cacert_file/1 but allows the use of
+%     certificates loaded from places other than a single file.
 %
 %     Additional verification of the peer certificate as well as
 %     accepting certificates that are not trusted by the given set

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -3551,8 +3551,7 @@ pl_ssl_context(term_t role, term_t config, term_t options, term_t method)
       while (PL_get_list_ex(CertTail, CertHead, CertTail))
       { X509* cert;
 	if (!get_certificate_blob(CertHead, &cert))
-	{ sk_X509_free(conf->cacerts);
-	  Sdprintf("failed here\n");
+        { sk_X509_free(conf->cacerts);
 	  conf->cacerts = NULL;
 	  return FALSE;
 	}
@@ -3560,7 +3559,6 @@ pl_ssl_context(term_t role, term_t config, term_t options, term_t method)
       }
       if (!PL_get_nil_ex(CertTail))
       { sk_X509_free(conf->cacerts);
-	Sdprintf("not a list\n");
 	conf->cacerts = NULL;
 	return FALSE;
       }


### PR DESCRIPTION
…aces other than a single file

This allows creating of CAs on-the-fly in code from various sources (such as rows in a database table) as well as trusting most-but-not-all of the system CAs

I'm not sure if the current approach of having 3 fields in the context to describe the trusted certificates is really optimal. Perhaps we should unify all 3 to load the X509 objects into a single cacerts field? The only real downside is this might waste a bit of memory having several copies of the CAs around. They're now only cleaned up by AGC as well, which might further compound things.