### PR TITLE
write_certificate assumed the underlying stream would accept raw byte…

### DIFF
--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -1379,7 +1379,7 @@ pl_write_certificate(term_t Sink, term_t Cert, term_t Options)
   if ( !PL_get_stream_handle(Sink, &stream) )
     return FALSE;
 
-  bio = BIO_new(bio_write_method());
+  bio = BIO_new(bio_write_text_method());
   BIO_set_ex_data(bio, 0, stream);
   rc = PEM_write_bio_X509(bio, x509);
   BIO_free(bio);


### PR DESCRIPTION
…s, but this is not necessarily the case. with_output_to/2 sets the encoding to wchar, for example.

This doesn't seem that efficient, but I suppose that ultimately looping over Sputcode is what will have to happen anyway.