### PR TITLE
Add same_certificate/2 to allow comparing certificates

### DIFF
--- a/ssl.pl
+++ b/ssl.pl
@@ -44,6 +44,7 @@
             cert_accept_any/5,            % +SSL, +ProblemCertificate,
                                           % +AllCertificates, +FirstCertificate,
                                           % +Error
+            same_certificate/2,           % +CertificateA, +CertificateB
             ssl_context/3,                % +Role, -Config, :Options
             ssl_add_certificate_key/4,    % +Config, +Cert, +Key, -Config
             ssl_set_options/3,            % +Config0, -Config, +Options
@@ -510,6 +511,12 @@ ssl_set_options(SSL0, SSL, Options) :-
 %                 [ cert_verify_hook(cert_accept_any)
 %                 ])
 %     ==
+
+%!  same_certificate(+CertificateA,
+%!                   +CertificateB).
+%
+%   True if CertificateA is logically the same as CertificateB, even if
+%   they are stored in different blobs
 
 %!  verify_certificate_issuer(+Certificate,
 %!			      +Issuer).

--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -1366,6 +1366,15 @@ pl_verify_certificate_issuer(term_t Certificate, term_t IssuerCertificate)
   return X509_check_issued(issuer_cert, cert);
 }
 
+static foreign_t
+pl_same_certificate(term_t A, term_t B)
+{ X509* a, *b;
+  if ( !get_certificate_blob(A, &a) )
+    return FALSE;
+  if ( !get_certificate_blob(B, &b) )
+    return FALSE;
+  return X509_cmp(a, b) == 0;
+}
 
 static foreign_t
 pl_write_certificate(term_t Sink, term_t Cert, term_t Options)
@@ -4199,6 +4208,7 @@ install_ssl4pl(void)
 
   PL_register_foreign("certificate_field", 2, pl_certificate_field, PL_FA_NONDETERMINISTIC);
   PL_register_foreign("verify_certificate_issuer", 2, pl_verify_certificate_issuer, 0);
+  PL_register_foreign("same_certificate", 2, pl_same_certificate, 0);
 
 /* Note that libcrypto threading needs to be initialized exactly once.
    This is achieved by loading library(crypto) from library(ssl) and


### PR DESCRIPTION
Currently, if you load the same certificate twice, you get different blobs for each instance, and since the pointers to the X509 struct underneath differ, they do not equal each other.

I have added same_certificate/2 to allow users to check if two certificate instances are actually equal