### PR TITLE
It turns out that X509_STORE_add_cert increments the reference count …

### DIFF
--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -2554,12 +2554,8 @@ ssl_init_verify_locations(PL_SSL *config)
   { X509_STORE *store = X509_STORE_new();
     if ( store )
     { int index = 0;
-      /* We make a duplicate of the certificate here since config->cacerts will be cleaned
-         up when the context is freed, but the store will also free all the certificates it
-         contains when the SSL object underlying the context is freed
-      */
       while (index < sk_X509_num(config->cacerts))
-      { X509_STORE_add_cert(store, X509_dup(sk_X509_value(config->cacerts, index++)));
+      { X509_STORE_add_cert(store, sk_X509_value(config->cacerts, index++));
       }
       SSL_CTX_set_cert_store(config->ctx, store);
     }


### PR DESCRIPTION
…on the certificate anyway. This isnt really documented in the OpenSSL documentation, but valgrind makes it pretty clear that we are leaking a lot of memory by duplicating the certificate

I also noticed while valgrinding that starting an HTTPS server then stopping it leaves a reference (somewhere) to the SSL context:

```

start_and_stop_https_server:-
        http_server(http_dispatch, [port(Port),
                                    ssl([certificate_file('untrusted.pem'),
                                         key_file('untrusted.key'),
                                         password(-)])]),
        http_stop_server(Port, []).


?- start_and_stop_https_server.
true.

?- start_and_stop_https_server.
true.

?- start_and_stop_https_server.
true.

?- start_and_stop_https_server.
true.

?- start_and_stop_https_server.
true.

?- garbage_collect_atoms.
true.

?- current_blob(X, ssl_context).
X = <ssl_context>(0x7f879d459250) ;
X = <ssl_context>(0x7f879d45a8a0) ;
X = <ssl_context>(0x7f879f1d71a0) ;
X = <ssl_context>(0x7f879d4a4fa0) ;
X = <ssl_context>(0x7f879f5de180) ;
false.
```

The equivalent case of calling `https_open('https://www.google.com', Stream, []), close(Stream)` does not leave these references. I couldn't work out where they were ending up stuck - without calling ssl_negotiate/5 we don't increment the reference count explicitly, and with no threads left I'm not sure where else to look. This isn't so important to me since I think stopping a web server is relatively uncommon, but it does make my Valgrind report a bit frightening since a tight loop of create-server, connect-to-server, stop-server, repeat leak a LOT of memory
