### PR TITLE
Saml fixes

### DIFF
--- a/saml.pl
+++ b/saml.pl
@@ -373,7 +373,8 @@ process_saml_response(XML0, ServiceProvider, Callback, RequestURL, Options):-
     ( member(element(ns(_, DS):'Signature', _, Signature), Response)->
         xmld_verify_signature(XML, Signature, Certificate, []),
         % Check that the certificate used to sign was one in the metadata
-        (  saml_idp_certificate(ServiceProvider, IssuerName, signing, Certificate)
+        (  saml_idp_certificate(ServiceProvider, IssuerName, signing, IDPCertificate),
+           same_certificate(Certificate, IDPCertificate)
         -> true
         ;  domain_error(trusted_certificate, Certificate)
         )
@@ -427,7 +428,8 @@ process_assertion(ServiceProvider, _EntityID, Document, Attributes, Assertion, A
     ( member(element(DS:'Signature', _, Signature), Assertion)->
         xmld_verify_signature(Document, Signature, Certificate, []),
         % Check that the certificate used to sign was one in the metadata
-        (  saml_idp_certificate(ServiceProvider, IssuerName, signing, Certificate)
+        (  saml_idp_certificate(ServiceProvider, IssuerName, signing, IDPCertificate),
+           same_certificate(Certificate, IDPCertificate)
         -> true
         ;  domain_error(trusted_certificate, Certificate)
         )


### PR DESCRIPTION
There was a bit of betroth here - this PR fixes SAML and XMLdsig code to use the new certificate API, and fixes a bug where we assumed the canonicalization method would be the default