### PR TITLE
Increase both certificate expiry time and CRL refresh time to 3 years

### DIFF
--- a/tests/1.cnf
+++ b/tests/1.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/10.cnf
+++ b/tests/10.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/11.cnf
+++ b/tests/11.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/12.cnf
+++ b/tests/12.cnf
@@ -32,7 +32,7 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crl_extensions	= crl_ext
 
 default_enddate	= 19990101120000Z       # Already expired
-default_crl_days= 30			# how long before next CRL
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/13.cnf
+++ b/tests/13.cnf
@@ -33,7 +33,7 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 
 default_startdate= 20800101120000Z      # I will be expired before this is valid
 default_days    = 365
-default_crl_days= 30			# how long before next CRL
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/14.cnf
+++ b/tests/14.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/14_tail.cnf
+++ b/tests/14_tail.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/15.cnf
+++ b/tests/15.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/16.cnf
+++ b/tests/16.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/17.cnf
+++ b/tests/17.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/18.cnf
+++ b/tests/18.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/18_tail.cnf
+++ b/tests/18_tail.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/19.cnf
+++ b/tests/19.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/19_tail.cnf
+++ b/tests/19_tail.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/2.cnf
+++ b/tests/2.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/20.cnf
+++ b/tests/20.cnf
@@ -32,7 +32,7 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crl_extensions	= crl_ext
 
 default_enddate	= 19990101120000Z       # Already expired
-default_crl_days= 30			# how long before next CRL
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/20_tail.cnf
+++ b/tests/20_tail.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/21.cnf
+++ b/tests/21.cnf
@@ -33,7 +33,7 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 
 default_startdate= 20800101120000Z      # I will be expired before this is valid
 default_days     = 365
-default_crl_days= 30			# how long before next CRL
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/21_tail.cnf
+++ b/tests/21_tail.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/22.cnf
+++ b/tests/22.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/22_tail.cnf
+++ b/tests/22_tail.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/23.cnf
+++ b/tests/23.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/24.cnf
+++ b/tests/24.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/25.cnf
+++ b/tests/25.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/25_tail.cnf
+++ b/tests/25_tail.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/26.cnf
+++ b/tests/26.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/26_tail.cnf
+++ b/tests/26_tail.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/27.cnf
+++ b/tests/27.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/27_tail.cnf
+++ b/tests/27_tail.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/3.cnf
+++ b/tests/3.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/4.cnf
+++ b/tests/4.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/5.cnf
+++ b/tests/5.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/6.cnf
+++ b/tests/6.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/7.cnf
+++ b/tests/7.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/8.cnf
+++ b/tests/8.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/9.cnf
+++ b/tests/9.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/client.cnf
+++ b/tests/client.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/demoCA.cnf
+++ b/tests/demoCA.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/rootCA.cnf
+++ b/tests/rootCA.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/tests/server.cnf
+++ b/tests/server.cnf
@@ -31,8 +31,8 @@ copy_extensions = copy                  # We need this to support the SubjectAlt
 # crlnumber must also be commented out to leave a V1 CRL.
 # crl_extensions	= crl_ext
 
-default_days	= 365                   # Already expired
-default_crl_days= 30			# how long before next CRL
+default_days	= 1095                   # Already expired
+default_crl_days= 1095			# how long before next CRL
 default_md	= default		# use public key default MD
 preserve	= no			# keep passed DN ordering
 


### PR DESCRIPTION
This will ensure that tests will pass 3 years after builds with no further actions required. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=968013

Lev Lamberov suggests that 3 years is appropriate since that matches the Debian release lifecycle. If you'd like, I can easily change this to 10 years, though