### PR TITLE
Fix build on OpenBSD 7.0

### DIFF
--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -4252,7 +4252,7 @@ pl_ssl_session(term_t stream_t, term_t session_t)
        !(session = SSL_get1_session(ssl)) )
     return PL_existence_error("ssl_session", stream_t);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3040000fL)
   version = session->ssl_version;
   master_key = session->master_key;
   master_key_length = session->master_key_length;
@@ -4288,7 +4288,7 @@ pl_ssl_session(term_t stream_t, term_t session_t)
 		       master_key_length, master_key) )
     goto err;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3040000fL)
   if ( !add_key_string(list_t, FUNCTOR_session_id1,
 		       session->session_id_length, session->session_id) )
     goto err;


### PR DESCRIPTION
LibreSSL now uses opaque structs like OpenSSL 1.1.0+.

After this patch, I can compile `packages/ssl`, but one test fails:

```
ERROR: /home/michael/src/swipl-devel/packages/ssl/test_ssl.pl:645:
        test Certificate is not intended for SSL: wrong answer (compared using ==)
ERROR:     Expected: [bad_certificate_use,verified]:true
ERROR:     Got:      []:error(error(ssl_error('1400A410','SSL routines','CONNECT_CR_CERT_REQ','sslv3 alert handshake failure'),A))
```

I spent a while trying to fix it, but I wasn't skilled enough with OpenSSL, LibreSSL, or ssl4pl to make any progress. I'm glad to update this pull request anyone has ideas how to fix the failing test.