### PR TITLE
Override OPENSSL_OS_LIBS with cmake -Detc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(Sockets)
 find_package(OpenSSL)
 if(OPENSSL_FOUND)
 
-if(WIN32)
+if(WIN32 AND NOT OPENSSL_OS_LIBS)
 set(OPENSSL_OS_LIBS ws2_32.lib gdi32.lib crypt32.lib)
 else()
 set(OPENSSL_OS_LIBS)


### PR DESCRIPTION
For some reasons, RTools40 needs libz included in the OPENSSL_OS_LIBS