### PR TITLE
Zero the PL_CRYPTO_HASH_CONTEXT struct on first allocation

### DIFF
--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -364,17 +364,12 @@ pl_crypto_hash_context_new(term_t tcontext, term_t options)
   PL_CRYPTO_HASH_CONTEXT *context = NULL;
 
   context = malloc(sizeof(*context));
+  memset(context, 0, sizeof(PL_CRYPTO_HASH_CONTEXT));
 
   if ( !context )
     return FALSE;
 
   context->magic    = HASH_CONTEXT_MAGIC;
-  context->ctx      = NULL;
-  context->mac_ctx  = NULL;
-  context->mac_key  = NULL;
-
-  context->parent_stream = NULL;
-  context->hash_stream   = NULL;
 
   if ( !hash_options(options, context) )
     return FALSE;

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -364,11 +364,11 @@ pl_crypto_hash_context_new(term_t tcontext, term_t options)
   PL_CRYPTO_HASH_CONTEXT *context = NULL;
 
   context = malloc(sizeof(*context));
-  memset(context, 0, sizeof(*context));
 
   if ( !context )
     return FALSE;
 
+  memset(context, 0, sizeof(*context));
   context->magic    = HASH_CONTEXT_MAGIC;
 
   if ( !hash_options(options, context) )

--- a/crypto4pl.c
+++ b/crypto4pl.c
@@ -364,7 +364,7 @@ pl_crypto_hash_context_new(term_t tcontext, term_t options)
   PL_CRYPTO_HASH_CONTEXT *context = NULL;
 
   context = malloc(sizeof(*context));
-  memset(context, 0, sizeof(PL_CRYPTO_HASH_CONTEXT));
+  memset(context, 0, sizeof(*context));
 
   if ( !context )
     return FALSE;


### PR DESCRIPTION
On first allocation, the `PL_CRYPTO_HASH_CONTEXT` was not properly zero'd (only some fields were explicitely set to NULL). This caused later code to think the mac context was there when it in fact wasn't.

The code that triggered this bug for me was in `pl_crypto_hash_context_copy`. This checks if the `mac` field is NULL. If not, it'll use the `mac_ctx` field.

Zeroing the whole struct will prevent bugs like this from cropping up in the future without having to explicitely remember to NULL-initialize new fields and such.

See also https://github.com/SWI-Prolog/swipl-devel/issues/1014.