### PR TITLE
Avoid warning on uninitialized variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(NOT DEFINED GET0SIG_CONST_T)
 	 int main() {
 	   const ASN1_BIT_STRING *psig;
 	   const X509_ALGOR *palg;
-	   const X509 *data;
+	   const X509 *data=NULL;
 
 	   X509_get0_signature(&psig, &palg, data);
 	   return 0;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,14 +71,14 @@ endif()
 if(NOT DEFINED GET0SIG_CONST_T)
   if(HAVE_X509_GET0_SIGNATURE)
     set(_cmake_saved_dlags ${CMAKE_REQUIRED_FLAGS})
-    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} -Werror=incompatible-pointer-types)
+    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} -Werror -c)
     check_c_source_compiles(
 	"#include <openssl/x509.h>
 
 	 int main() {
 	   const ASN1_BIT_STRING *psig;
 	   const X509_ALGOR *palg;
-	   const X509 *data;
+	   const X509 *data=NULL;
 
 	   X509_get0_signature(&psig, &palg, data);
 	   return 0;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,14 +71,14 @@ endif()
 if(NOT DEFINED GET0SIG_CONST_T)
   if(HAVE_X509_GET0_SIGNATURE)
     set(_cmake_saved_dlags ${CMAKE_REQUIRED_FLAGS})
-    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} -Werror)
+    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} -Werror=incompatible-pointer-types)
     check_c_source_compiles(
 	"#include <openssl/x509.h>
 
 	 int main() {
 	   const ASN1_BIT_STRING *psig;
 	   const X509_ALGOR *palg;
-	   const X509 *data=NULL;
+	   const X509 *data;
 
 	   X509_get0_signature(&psig, &palg, data);
 	   return 0;


### PR DESCRIPTION
The little program is meant to produce a warning if the first argument of X509_get0_signature(&psig, &palg, data) is not declared const. It's compiled with -Werror. On my Windows, a warning interferes this test, namely, that data is uninitialized.