### PR TITLE
Update for openssl 4.0

### DIFF
--- a/ssl4pl.c
+++ b/ssl4pl.c
@@ -74,6 +74,12 @@
 
 #define SSL_MAX_CERT_KEY_PAIRS 12
 
+#if OPENSSL_API_LEVEL < 40000
+#define ASN1_STRING_get0_data(x) (x)->data
+#define ASN1_STRING_length(x)    (x)->length
+#define ASN1_STRING_type(x)      (x)->type
+#endif
+
 typedef int BOOL;
 #ifndef TRUE
 #define TRUE 1
@@ -458,12 +464,12 @@ unify_asn1_time(term_t term, const ASN1_TIME *time)
 { time_t result = 0;
   char buffer[24];
   char* pbuffer = buffer;
-  size_t length = time->length;
-  char * source = (char *)time->data;
+  size_t length = ASN1_STRING_length(time);
+  const char * source = (const char *)ASN1_STRING_get0_data(time);
   struct tm time_tm;
   time_t lSecondsFromUTC;
 
-  if (time->type == V_ASN1_UTCTIME)
+  if (ASN1_STRING_type(time) == V_ASN1_UTCTIME)
   {  if ((length < 11) || (length > 17))
      {  ssl_deb(2, "Unable to parse time - expected either 11 or 17 chars,"
 		   " not %d", length);
@@ -616,7 +622,7 @@ unify_hash(term_t hash, const ASN1_OBJECT* algorithm,
 
 
 static int
-unify_name(term_t term, X509_NAME* name)
+unify_name(term_t term, const X509_NAME* name)
 { int ni;
   term_t list = PL_copy_term_ref(term);
   term_t item = PL_new_term_ref();
@@ -625,8 +631,8 @@ unify_name(term_t term, X509_NAME* name)
     return PL_unify_term(term, PL_CHARS, "<null>");
 
   for (ni = 0; ni < X509_NAME_entry_count(name); ni++)
-  { X509_NAME_ENTRY* e = X509_NAME_get_entry(name, ni);
-    ASN1_STRING* entry_data = X509_NAME_ENTRY_get_data(e);
+  { const X509_NAME_ENTRY* e = X509_NAME_get_entry(name, ni);
+    const ASN1_STRING* entry_data = X509_NAME_ENTRY_get_data(e);
     unsigned char *utf8_data;
     int rc;
 
@@ -678,7 +684,7 @@ unify_crl(term_t term, X509_CRL* crl)
   if (!(unify_name(issuer, X509_CRL_get_issuer(crl)) &&
 	unify_hash(hash, palg->algorithm, hash_X509_crl_digest_wrapper, crl) &&
         unify_asn1_time(next_update, X509_CRL_get0_nextUpdate(crl)) &&
-        unify_bytes_hex(signature, psig->length, psig->data) &&
+        unify_bytes_hex(signature, ASN1_STRING_length(psig), ASN1_STRING_get0_data(psig)) &&
         PL_unify_term(term,
                       PL_LIST, 5,
                       PL_FUNCTOR, FUNCTOR_issuername1,
@@ -1205,7 +1211,7 @@ fetch_public_key(term_t Field, X509* cert)
 static foreign_t
 fetch_crls(term_t Field, X509* cert)
 { unsigned int crl_ext_id;
-  X509_EXTENSION * crl_ext = NULL;
+  const X509_EXTENSION * crl_ext = NULL;
 
   crl_ext_id = X509_get_ext_by_NID(cert, NID_crl_distribution_points, -1);
   crl_ext = X509_get_ext(cert, crl_ext_id);
@@ -1232,7 +1238,7 @@ fetch_crls(term_t Field, X509* cert)
         { name = sk_GENERAL_NAME_value(point->distpoint->name.fullname, j);
           if (name != NULL && name->type == GEN_URI)
           { if (!(PL_unify_list(crl_list, crl_item, crl_list) &&
-                  PL_unify_atom_chars(crl_item, (const char *)name->d.ia5->data)))
+                  PL_unify_atom_chars(crl_item, (const char *)ASN1_STRING_get0_data(name->d.ia5))))
             {
               CRL_DIST_POINTS_free(distpoints);
               return FALSE;
@@ -1254,7 +1260,7 @@ fetch_crls(term_t Field, X509* cert)
 static foreign_t
 fetch_sans(term_t Field, X509* cert)
 { unsigned int san_ext_id;
-  X509_EXTENSION * san_ext = NULL;
+  const X509_EXTENSION * san_ext = NULL;
 
   san_ext_id = X509_get_ext_by_NID(cert, NID_subject_alt_name, -1);
   san_ext = X509_get_ext(cert, san_ext_id);
@@ -1293,7 +1299,7 @@ fetch_signature(term_t Field, X509* cert)
 { const ASN1_BIT_STRING *psig;
   const X509_ALGOR *palg;
   X509_get0_signature(&psig, &palg, cert);
-  return unify_bytes_hex(Field, psig->length, psig->data);
+  return unify_bytes_hex(Field, ASN1_STRING_length(psig), ASN1_STRING_get0_data(psig));
 }
 
 


### PR DESCRIPTION
Fedora Rawhide (which will become Fedora 45 in about 6 months) just moved from openssl 3.x to 4.x.  A number of packages now fail to build, including swipl.  This PR is my attempt at addressing the issue.  Two changes in openssl 4.x are responsible:
- Some types are now opaque, so accessor functions must be used instead of directly accessing structure fields
- Some function return types are now `const`

This PR leaves the code able to build with both openssl 3.x and 4.x.  I am happy to make changes to this PR if you don't like the style or the approach.

Also note the existence of an `ASN1_TIME_to_tm` function, but it isn't clear to me that it meets the needs of `unify_asn1_time`, so I didn't use it.
